### PR TITLE
Add notice create/update/delete endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ apispec==4.0.0
 canonicalwebteam.flask-base==0.7.1
 Flask==1.1.2
 flask-apispec==0.11.0
+launchpadlib==1.10.13
+macaroonbakery==1.3.1
 marshmallow==3.9.1
 python-dateutil==2.8.1
 psycopg2-binary==2.8.6

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,9 +1,18 @@
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
 from canonicalwebteam.flask_base.app import FlaskBase
+from flask import jsonify, make_response
 
-from webapp.views import get_cve, get_notice, get_cves, get_notices
 from webapp.api_spec import WebappFlaskApiSpec
+from webapp.views import (
+    get_cve,
+    get_notice,
+    get_cves,
+    get_notices,
+    create_notice,
+    update_notice,
+    delete_notice,
+)
 
 app = FlaskBase(
     __name__,
@@ -47,8 +56,42 @@ app.add_url_rule(
     provide_automatic_options=False,
 )
 
+app.add_url_rule(
+    "/security/notices",
+    view_func=create_notice,
+    methods=["POST"],
+    provide_automatic_options=False,
+)
+
+app.add_url_rule(
+    "/security/notices/<notice_id>",
+    view_func=update_notice,
+    methods=["PUT"],
+    provide_automatic_options=False,
+)
+
+app.add_url_rule(
+    "/security/notices/<notice_id>",
+    view_func=delete_notice,
+    methods=["DELETE"],
+    provide_automatic_options=False,
+)
+
 docs = WebappFlaskApiSpec(app)
 docs.register(get_cve)
 docs.register(get_cves)
 docs.register(get_notice)
 docs.register(get_notices)
+docs.register(create_notice)
+docs.register(update_notice)
+docs.register(delete_notice)
+
+
+@app.errorhandler(422)
+def handle_error(error):
+    messages = error.data.get("messages")
+
+    return make_response(
+        jsonify({"message": "Invalid payload", "errors": messages["json"]}),
+        422,
+    )

--- a/webapp/auth.py
+++ b/webapp/auth.py
@@ -1,0 +1,115 @@
+# Standard library
+from datetime import datetime, timedelta
+
+# Packages
+import flask
+from launchpadlib.launchpad import Launchpad
+from macaroonbakery import bakery, checkers, httpbakery
+from functools import wraps
+
+AUTHORIZED_TEAMS = [
+    "canonical-security-web",
+    "canonical-security",
+    "canonical-webmonkeys",
+]
+
+IDENTITY_CAVEATS = [
+    checkers.need_declared_caveat(
+        checkers.Caveat(
+            location="https://api.jujucharms.com/identity",
+            condition="is-authenticated-user",
+        ),
+        ["username"],
+    )
+]
+
+
+class Identity(bakery.Identity):
+    """Identity information for a Candid third party caveat."""
+
+    def __init__(self, identity):
+        parts = identity.split("@", 1)
+        self._username = parts[0]
+        self._domain = parts[1] if len(parts) == 2 else ""
+
+    def username(self):
+        return self._username
+
+    def domain(self):
+        return self._domain
+
+
+class IdentityClient(bakery.IdentityClient):
+    """Basic identity client based on the username returned by Candid."""
+
+    def identity_from_context(self, ctx):
+        return None, IDENTITY_CAVEATS
+
+    def declared_identity(self, ctx, declared):
+        """Return the identity from the given declared attributes."""
+        username = declared.get("username")
+        if username is None:
+            raise bakery.IdentityError("no username found")
+        return Identity(username)
+
+
+def authorization_required(func):
+    """
+    Decorator that checks if a user is logged in, and redirects
+    to login page if not.
+    """
+
+    @wraps(func)
+    def is_authorized(*args, **kwargs):
+        macaroon_bakery = bakery.Bakery(
+            location="ubuntu.com/security",
+            locator=httpbakery.ThirdPartyLocator(),
+            identity_client=IdentityClient(),
+            key=bakery.generate_key(),
+            root_key_store=bakery.MemoryKeyStore(
+                flask.current_app.config["SECRET_KEY"]
+            ),
+        )
+        macaroons = httpbakery.extract_macaroons(flask.request.headers)
+        auth_checker = macaroon_bakery.checker.auth(macaroons)
+        launchpad = Launchpad.login_anonymously(
+            "ubuntu.com/security", "production", version="devel"
+        )
+
+        try:
+            auth_info = auth_checker.allow(
+                checkers.AuthContext(), [bakery.LOGIN_OP]
+            )
+        except bakery._error.DischargeRequiredError:
+            macaroon = macaroon_bakery.oven.macaroon(
+                version=bakery.VERSION_2,
+                expiry=datetime.utcnow() + timedelta(weeks=4),
+                caveats=IDENTITY_CAVEATS,
+                ops=[bakery.LOGIN_OP],
+            )
+
+            content, headers = httpbakery.discharge_required_response(
+                macaroon, "/", "cookie-suffix"
+            )
+            return content, 401, headers
+
+        username = auth_info.identity.username()
+        lp_user = launchpad.people(username)
+        authorized = False
+
+        for team in AUTHORIZED_TEAMS:
+            if lp_user in launchpad.people(team).members:
+                authorized = True
+                break
+
+        if not authorized:
+            return (
+                f"{username} is not in any of the authorized teams: "
+                f"{str(AUTHORIZED_TEAMS)}",
+                401,
+            )
+
+        # Validate authentication token
+        return func(*args, **kwargs)
+
+    return is_authorized

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -35,7 +35,10 @@ class ReleaseCodename(String):
     }
 
     def _deserialize(self, value, attr, data, **kwargs):
-        if value not in self.context["release_codenames"]:
+        if (
+            "release_codenames" in self.context
+            and value not in self.context["release_codenames"]
+        ):
             raise self.make_error("unrecognised_codename", input=value)
 
         return super()._deserialize(value, attr, data, **kwargs)
@@ -91,7 +94,7 @@ class NoticeSchema(Schema):
     instructions = String(required=True)
     references = List(String())
     published = ParsedDateTime(required=True)
-    details = String(allow_none=True)
+    description = String(allow_none=True)
     release_packages = Dict(
         keys=ReleaseCodename(),
         values=List(Nested(NoticePackage), required=True),
@@ -115,8 +118,6 @@ class NoticesAPISchema(Schema):
     total_results = Int()
 
 
-# TODO: This should be a Schema object, but parameters won't load that way
-# https://github.com/canonical-web-and-design/security-metadata.canonical.com/issues/15
 NoticesParameters = {
     "details": String(allow_none=True),
     "release": String(allow_none=True),
@@ -204,8 +205,6 @@ class CVEsAPISchema(Schema):
     total_results = Int()
 
 
-# TODO: This should be a Schema object, but parameters won't load that way
-# https://github.com/canonical-web-and-design/security-metadata.canonical.com/issues/15
 CVEsParameters = {
     "q": String(allow_none=True),
     "priority": String(allow_none=True),
@@ -216,3 +215,12 @@ CVEsParameters = {
     "version": List(String(), allow_none=True),
     "status": List(String(), allow_none=True),
 }
+
+
+class MessageSchema(Schema):
+    message = String()
+
+
+class MessageWithErrorsSchema(Schema):
+    message = String()
+    errors = String()


### PR DESCRIPTION
## Done

Add create/update/delete notice endpoints. 

## QA
Open a terminal tab 1:
- `git clone git@github.com:albertkol/ubuntu-cve-tracker.git`
- Check out master and get the env up. There are 3 scripts we will be using to test the endpoints: `/scripts/create-notice`, `/scripts/update-notice` and `/scripts/delete`

Open New terminal tab 2: 
- Fetch PR changes
- `docker-compose up -d`
- `dotrun`
- Browse to http://0.0.0.0:8030/security/api/docs you should see the documentation with the new endpoints for create, update and delete.

Open New terminal tab 3: 
- `docker exec -it security_db psql -u postgres`
- Run: `select count(*) from notice;` notice the number
- Run: `select count(*) from notice_cves` notice the number

Testing create notice:
- Terminal 3 run: `select id,instructions from notice where id='LSN-0000-0';` You will get no results
- Terminal 1 run: `python3 ./scripts/create-notice.py`
- Terminal 3 run: `select id,instructions from notice where id='LSN-0000-0';` You will get results
- Terminal 3 run: `select count(*) from notice_cves` notice the number increased or `select * from notice_cves where notice_id='LSN-0000-0'`

Testing update notice:
- Terminal 1 run: `python3 ./scripts/update-notice.py`
- Terminal 3 run: `select id,instructions from notice where id='LSN-0000-0';` You will get results updated

Testing delete notice:
- Terminal 1 run: `python3 ./scripts/delete-notice.py`
- Terminal 3 run: `select id,instructions from notice where id='LSN-0000-0';` You will no results
- Terminal 3 run: `select count(*) from notice_cves` notice the number decreased or `select * from notice_cves where notice_id='LSN-0000-0'` returns no results

## Issue / Card

Fixes #13 
