### PR TITLE
Improve API documentation

### DIFF
--- a/webapp/alembic/versions/0fe2f3a871da_update_release_12_04.py
+++ b/webapp/alembic/versions/0fe2f3a871da_update_release_12_04.py
@@ -1,0 +1,31 @@
+"""update-release-12-04
+
+Revision ID: 0fe2f3a871da
+Revises: 88f1398da6c1
+Create Date: 2021-01-15 15:15:19.145893
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "0fe2f3a871da"
+down_revision = "88f1398da6c1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        "UPDATE release "
+        "SET esm_expires='2019-04-30 00:00:00' "
+        "WHERE version='12.04';"
+    )
+
+
+def downgrade():
+    op.execute(
+        "UPDATE release "
+        "SET esm_expires='2021-04-30 00:00:00' "
+        "WHERE version='12.04';"
+    )

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -92,6 +92,6 @@ def handle_error(error):
     messages = error.data.get("messages")
 
     return make_response(
-        jsonify({"message": "Invalid payload", "errors": messages["json"]}),
+        jsonify({"message": "Invalid payload", "errors": str(messages)}),
         422,
     )

--- a/webapp/database.py
+++ b/webapp/database.py
@@ -1,10 +1,24 @@
 import os
 
 from sqlalchemy import create_engine
+from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.orm import scoped_session, sessionmaker
 
+from webapp.models import Release
 
 db_engine = create_engine(os.environ["DATABASE_URL"])
 db_session = scoped_session(
     sessionmaker(autocommit=False, autoflush=False, bind=db_engine)
 )
+
+release_codenames = []
+inspector = Inspector.from_engine(db_engine)
+if "release" in inspector.get_table_names():
+    release_codenames = [
+        rel.codename for rel in db_session.query(Release).all()
+    ]
+
+status_statuses = []
+for enum in inspector.get_enums():
+    if enum["name"] == "statuses":
+        status_statuses = enum["labels"]

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -108,58 +108,6 @@ class CVE(Base):
     def notices_ids(self):
         return [notice.id for notice in self.notices]
 
-    @hybrid_property
-    def active_status_tree(self):
-        active_package_statuses = {}
-
-        for package_name, release_statuses in self.packages.items():
-            for status in release_statuses.values():
-                if (
-                    status.status in Status.active_statuses
-                    and status.release.version
-                    and status.release.support_tag
-                ):
-                    active_package_statuses[package_name] = release_statuses
-
-        return active_package_statuses
-
-    @hybrid_property
-    def formatted_patches(self):
-        return {
-            package_name: [self._format_patch(p) for p in patches]
-            for (package_name, patches) in self.patches.items()
-        }
-
-    def _format_patch(self, patch):
-        if ":" not in patch:
-            return {"type": "text", "content": patch}
-
-        prefix, suffix = patch.split(":", 1)
-        suffix = suffix.strip()
-        if prefix == "break-fix" and " " in suffix:
-            introduced, fixed = suffix.split(" ", 1)
-            if introduced == "-":
-                # First commit to Linux git tree
-                introduced = "1da177e4c3f41524e886b7f1b8a0c1fc7321cac2"
-
-            return {
-                "type": "break-fix",
-                "content": {"introduced": introduced, "fixed": fixed},
-            }
-        if "ftp://" in suffix or "http://" in suffix or "https://" in suffix:
-            return {
-                "type": "link",
-                "content": {"prefix": prefix.capitalize(), "suffix": suffix},
-            }
-
-        return {"type": "text", "content": patch}
-
-    def __getitem__(self, key):
-        return getattr(self, key)
-
-    def __setitem__(self, key, value):
-        return setattr(self, key, value)
-
 
 class Notice(Base):
     __tablename__ = "notice"
@@ -185,29 +133,13 @@ class Notice(Base):
         return [cve.id for cve in self.cves]
 
     @hybrid_property
-    def package_list(self):
-        if not self.release_packages:
-            return []
+    def notice_type(self):
+        if "USN-" in self.id.upper():
+            return "USN"
+        if "LSN-" in self.id.upper():
+            return "LSN"
 
-        package_list = []
-        for codename, packages in self.release_packages.items():
-            for package in packages:
-                package_list.append(package["name"])
-
-        return set(sorted(package_list))
-
-    def as_dict(self):
-        return {
-            "id": self.id,
-            "title": self.title,
-            "published": self.published,
-            "summary": self.summary,
-            "details": self.details,
-            "instructions": self.instructions,
-            "references": self.references,
-            "release_packages": self.release_packages,
-            "cves": [c.id for c in self.cves],
-        }
+        return ""
 
 
 class Release(Base):

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -106,6 +106,7 @@ class NoticeImportSchema(NoticeSchema):
 
 
 class NoticeAPISchema(NoticeSchema):
+    notice_type = String(data_key="type")
     cves_ids = List(
         String(validate=Regexp(r"(cve-|CVE-)\d{4}-\d{4,7}")), data_key="cves"
     )
@@ -138,6 +139,10 @@ class ReleaseSchema(Schema):
     release_date = ParsedDateTime(required=True)
     esm_expires = ParsedDateTime(required=True)
     support_expires = ParsedDateTime(required=True)
+
+
+class ReleaseAPISchema(ReleaseSchema):
+    support_tag = String()
 
 
 # CVEs

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -12,6 +12,8 @@ from marshmallow.fields import (
 )
 from marshmallow.validate import Regexp
 
+from webapp.database import release_codenames
+
 
 # Types
 # ===
@@ -35,10 +37,7 @@ class ReleaseCodename(String):
     }
 
     def _deserialize(self, value, attr, data, **kwargs):
-        if (
-            "release_codenames" in self.context
-            and value not in self.context["release_codenames"]
-        ):
+        if value not in release_codenames:
             raise self.make_error("unrecognised_codename", input=value)
 
         return super()._deserialize(value, attr, data, **kwargs)
@@ -46,7 +45,7 @@ class ReleaseCodename(String):
 
 class Component(String):
     default_error_messages = {
-        "unrecognised_component": ("Component must be 'main' or 'universe'")
+        "unrecognised_component": "Component must be 'main' or 'universe'"
     }
 
     def _deserialize(self, value, attr, data, **kwargs):

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -12,7 +12,7 @@ from marshmallow.fields import (
 )
 from marshmallow.validate import Regexp
 
-from webapp.database import release_codenames
+from webapp.database import release_codenames, status_statuses
 
 
 # Types
@@ -119,11 +119,33 @@ class NoticesAPISchema(Schema):
 
 
 NoticesParameters = {
-    "details": String(allow_none=True),
-    "release": String(allow_none=True),
-    "limit": Int(allow_none=True),
-    "offset": Int(allow_none=True),
-    "order": String(allow_none=True),
+    "details": String(
+        description=(
+            "Any string -  Selects notices that have either "
+            "id, details or cves.id matching it"
+        ),
+        allow_none=True,
+    ),
+    "release": String(
+        description="List of release codenames",
+        allow_none=True,
+    ),
+    "limit": Int(
+        description="Number of CVEs per response. Defaults to 20.",
+        allow_none=True,
+    ),
+    "offset": Int(
+        description="Number of CVEs to omit from response. Defaults to 0.",
+        allow_none=True,
+    ),
+    "order": String(
+        enum=["oldest"],
+        description=(
+            "Select order: choose `oldest` for ASC order; "
+            "leave empty for DESC order"
+        ),
+        allow_none=True,
+    ),
 }
 
 
@@ -210,15 +232,50 @@ class CVEsAPISchema(Schema):
 
 
 CVEsParameters = {
-    "q": String(allow_none=True),
-    "priority": String(allow_none=True),
-    "package": String(allow_none=True),
-    "limit": Int(allow_none=True),
-    "offset": Int(allow_none=True),
-    "component": String(allow_none=True),
-    "version": List(String(), allow_none=True),
-    "status": List(String(), allow_none=True),
-    "order": String(allow_none=True),
+    "q": String(
+        description=(
+            "Any string -  Selects CVEs that have either "
+            "id, description or ubuntu_description matching it"
+        ),
+        allow_none=True,
+    ),
+    "priority": String(
+        description="CVE priority",
+        enum=["unknown", "negligible", "low", "medium", "high", "critical"],
+        allow_none=True,
+    ),
+    "package": String(description="Package name", allow_none=True),
+    "limit": Int(
+        description="Number of CVEs per response. Defaults to 20.",
+        allow_none=True,
+    ),
+    "offset": Int(
+        description="Number of CVEs to omit from response. Defaults to 0.",
+        allow_none=True,
+    ),
+    "component": String(
+        allow_none=True,
+        enum=["main", "universe"],
+        description="Package component",
+    ),
+    "version": List(
+        String(enum=release_codenames),
+        description="List of release codenames ",
+        allow_none=True,
+    ),
+    "status": List(
+        String(enum=status_statuses),
+        description="List of statuses",
+        allow_none=True,
+    ),
+    "order": String(
+        enum=["oldest"],
+        description=(
+            "Select order: choose `oldest` for ASC order; "
+            "leave empty for DESC order"
+        ),
+        allow_none=True,
+    ),
 }
 
 

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -219,6 +219,7 @@ CVEsParameters = {
     "component": String(allow_none=True),
     "version": List(String(), allow_none=True),
     "status": List(String(), allow_none=True),
+    "order": String(allow_none=True),
 }
 
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -66,6 +66,7 @@ def get_cves(**kwargs):
     if query:
         cves_query = cves_query.filter(
             or_(
+                CVE.id.ilike(f"%{query}%"),
                 CVE.description.ilike(f"%{query}%"),
                 CVE.ubuntu_description.ilike(f"%{query}%"),
             )


### PR DESCRIPTION
## Done

- Bring API in line with the latest changes from ubuntu.com.
- Delete some useless stuff from models that are processing the data. The API's job is to just read the data from the database, processing how the data is displayed should be kept to a minimum
- fix bug `order` parameter for cves endpoint it was not listed
- fix bug `q` to pattern check for cve.id too
- Refactor how we select statuses enum form the databse
- Refactor errors
- Add details to parameters and list enum values

## QA
- Fetch changes
- have database
- `dotrun`

Test `order`:
- Browse to http://0.0.0.0:8030/security/cves.json?package=firefox&order=oldest if you look at the `published` property you will see that the CVEs are ordered in ASC order (ctrl+f for "published"). If you remove it from the query they will be listed in DESC order.

Test `q` change:
- Browse to http://0.0.0.0:8030/security/cves.json?q=2014-4715 it will list two CVEs. Before only `CVE-2014-4611` would show up. (`CVE-2014-4715` because it matches the cve.id; `CVE-2014-4611` because `2014-4715` appears in the `cve.description`)

Check parameter details:
- Look at /security/cves.json endpoint - the parameters should have descriptions 
- Look at /security/notices.json endpoint - the parameters should have descriptions 