### PR TITLE
Improve API validation

### DIFF
--- a/webapp/database.py
+++ b/webapp/database.py
@@ -11,8 +11,9 @@ db_session = scoped_session(
     sessionmaker(autocommit=False, autoflush=False, bind=db_engine)
 )
 
-release_codenames = []
 inspector = Inspector.from_engine(db_engine)
+
+release_codenames = []
 if "release" in inspector.get_table_names():
     release_codenames = [
         rel.codename for rel in db_session.query(Release).all()

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -12,8 +12,13 @@ from marshmallow.fields import (
 )
 from marshmallow.validate import Regexp
 
-from webapp.database import release_codenames, status_statuses
-
+from webapp.database import (
+    release_codenames,
+    status_statuses,
+    db_session,
+    inspector,
+)
+from webapp.models import Package, Notice
 
 # Types
 # ===
@@ -51,6 +56,62 @@ class Component(String):
     def _deserialize(self, value, attr, data, **kwargs):
         if value not in ["main", "universe"]:
             raise self.make_error("unrecognised_component", input=value)
+
+        return super()._deserialize(value, attr, data, **kwargs)
+
+
+class StatusStatuses(String):
+    default_error_messages = {
+        "unrecognised_status": "Cannot find a status with status {input}"
+    }
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if value not in status_statuses:
+            raise self.make_error("unrecognised_status", input=value)
+
+        return super()._deserialize(value, attr, data, **kwargs)
+
+
+class UniqueNoticeId(String):
+    default_error_messages = {
+        "notice_id_exists": "Notice with id '{input}' already exists"
+    }
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        exists = False
+
+        if "notice" in inspector.get_table_names():
+            exists = (
+                db_session.query(Notice)
+                .filter(Notice.id == value)
+                .one_or_none()
+                is not None
+            )
+
+        if exists:
+            raise self.make_error("notice_id_exists", input=value)
+
+        return super()._deserialize(value, attr, data, **kwargs)
+
+
+class PackageName(String):
+    default_error_messages = {
+        "unrecognised_package_name": "No CVEs with package '{input}' found"
+    }
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        exists = False
+
+        if "package" in inspector.get_table_names():
+            exists = (
+                db_session.query(Package.name)
+                .filter_by(name=value)
+                .one_or_none()
+                is not None
+            )
+
+        if not exists:
+            raise self.make_error("unrecognised_package_name", input=value)
 
         return super()._deserialize(value, attr, data, **kwargs)
 
@@ -104,6 +165,12 @@ class NoticeImportSchema(NoticeSchema):
     cves = List(String(validate=Regexp(r"(cve-|CVE-)\d{4}-\d{4,7}")))
 
 
+class CreateNoticeImportSchema(NoticeImportSchema):
+    id = UniqueNoticeId(
+        required=True, validate=Regexp(r"(USN|LSN)-\d{1,5}-\d{1,2}")
+    )
+
+
 class NoticeAPISchema(NoticeSchema):
     notice_type = String(data_key="type")
     cves_ids = List(
@@ -121,12 +188,13 @@ class NoticesAPISchema(Schema):
 NoticesParameters = {
     "details": String(
         description=(
-            "Any string -  Selects notices that have either "
+            "Any string - Selects notices that have either "
             "id, details or cves.id matching it"
         ),
         allow_none=True,
     ),
-    "release": String(
+    "release": ReleaseCodename(
+        enum=release_codenames,
         description="List of release codenames",
         allow_none=True,
     ),
@@ -170,7 +238,7 @@ class ReleaseAPISchema(ReleaseSchema):
 # --
 class Status(Schema):
     release_codename = ReleaseCodename(required=True)
-    status = String(required=True)
+    status = StatusStatuses(required=True)
     description = String(allow_none=True)
     component = Component(required=False)
     pocket = Pocket(required=False)
@@ -244,7 +312,7 @@ CVEsParameters = {
         enum=["unknown", "negligible", "low", "medium", "high", "critical"],
         allow_none=True,
     ),
-    "package": String(description="Package name", allow_none=True),
+    "package": PackageName(description="Package name", allow_none=True),
     "limit": Int(
         description="Number of CVEs per response. Defaults to 20.",
         allow_none=True,
@@ -253,18 +321,18 @@ CVEsParameters = {
         description="Number of CVEs to omit from response. Defaults to 0.",
         allow_none=True,
     ),
-    "component": String(
+    "component": Component(
         allow_none=True,
         enum=["main", "universe"],
         description="Package component",
     ),
     "version": List(
-        String(enum=release_codenames),
+        ReleaseCodename(enum=release_codenames),
         description="List of release codenames ",
         allow_none=True,
     ),
     "status": List(
-        String(enum=status_statuses),
+        StatusStatuses(enum=status_statuses),
         description="List of statuses",
         allow_none=True,
     ),

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from flask import make_response, jsonify, request
 from flask_apispec import marshal_with, use_kwargs
 from sqlalchemy import desc, or_, func, and_, case, asc
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import contains_eager
 
 from webapp.auth import authorization_required
@@ -19,6 +18,7 @@ from webapp.schemas import (
     NoticeImportSchema,
     MessageSchema,
     MessageWithErrorsSchema,
+    CreateNoticeImportSchema,
 )
 
 
@@ -276,7 +276,7 @@ def get_notices(**kwargs):
 @authorization_required
 @marshal_with(MessageSchema, code=200)
 @marshal_with(MessageWithErrorsSchema, code=422)
-@use_kwargs(NoticeImportSchema, location="json")
+@use_kwargs(CreateNoticeImportSchema, location="json")
 def create_notice(**kwargs):
     notice_data = request.json
 
@@ -284,27 +284,7 @@ def create_notice(**kwargs):
         _update_notice_object(Notice(id=notice_data["id"]), notice_data)
     )
 
-    try:
-        db_session.commit()
-    except IntegrityError:
-        return make_response(
-            jsonify(
-                {
-                    "message": "Invalid payload",
-                    "errors": str(
-                        {
-                            "json": {
-                                "id": [
-                                    f"Notice '{notice_data['id']}' "
-                                    f"already exists"
-                                ]
-                            },
-                        }
-                    ),
-                }
-            ),
-            422,
-        )
+    db_session.commit()
 
     return make_response(jsonify({"message": "Notice created"}), 200)
 
@@ -378,7 +358,7 @@ def _get_clean_statuses(statuses, versions):
         return clean_statuses
 
     for status in statuses:
-        if status != "":
+        if status != "" and status in status_statuses:
             clean_statuses.append([status])
         else:
             clean_statuses.append(status_statuses)


### PR DESCRIPTION
## Done

The API validates:
- Every `version`/`release` and `status` parameter to be a valid `enum` value;
- Validate `package` parameter
- Validate for unique `notice_id` at `notice_create`

## QA

- Fetch changes
- Fetch my tracker repo (`git clone git@github.com:albertkol/ubuntu-cve-tracker.git`) and checkout master (or fetch latest master)
- Run `python3 ./scripts/api-tests.py`
- Look at the responses and confirm the expectations match the received errors

## Issue / Card

Fixes #24