### PR TITLE
Add default filter to model and id_hidden to USN

### DIFF
--- a/webapp/alembic/versions/8008e46e6ea8_add_is_hidden_column_for_notices.py
+++ b/webapp/alembic/versions/8008e46e6ea8_add_is_hidden_column_for_notices.py
@@ -1,0 +1,32 @@
+"""add_is_hidden_column_for_notices
+
+Revision ID: 8008e46e6ea8
+Revises: 3e0a3f15abb9
+Create Date: 2021-02-19 12:39:11.459139
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "8008e46e6ea8"
+down_revision = "3e0a3f15abb9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "notice",
+        sa.Column(
+            "is_hidden",
+            sa.Boolean(),
+            nullable=False,
+            server_default="False",
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("notice", "is_hidden")

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -4,6 +4,7 @@ from canonicalwebteam.flask_base.app import FlaskBase
 from flask import jsonify, make_response
 
 from webapp.api_spec import WebappFlaskApiSpec
+from webapp.database import db_session
 from webapp.views import (
     get_cve,
     get_notice,
@@ -135,3 +136,10 @@ def handle_error(error):
         jsonify({"message": "Invalid payload", "errors": str(messages)}),
         422,
     )
+
+
+@app.teardown_appcontext
+def remove_db_session(response):
+    db_session.remove()
+
+    return response

--- a/webapp/database.py
+++ b/webapp/database.py
@@ -4,11 +4,16 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.orm import scoped_session, sessionmaker
 
-from webapp.models import Release
+from webapp.models import Release, BaseFilterQuery
 
 db_engine = create_engine(os.environ["DATABASE_URL"])
 db_session = scoped_session(
-    sessionmaker(autocommit=False, autoflush=False, bind=db_engine)
+    sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        bind=db_engine,
+        query_cls=BaseFilterQuery,
+    )
 )
 
 inspector = Inspector.from_engine(db_engine)

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -14,8 +14,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import relationship
-
+from sqlalchemy.orm import relationship, Query
 
 Base = declarative_base()
 
@@ -122,6 +121,7 @@ class Notice(Base):
     release_packages = Column(JSON)
     cves = relationship("CVE", secondary=notice_cves, back_populates="notices")
     references = Column(JSON)
+    is_hidden = Column(Boolean)
     releases = relationship(
         "Release",
         secondary=notice_releases,
@@ -141,6 +141,10 @@ class Notice(Base):
             return "LSN"
 
         return ""
+
+    @classmethod
+    def _base_filters(self):
+        return self.is_hidden == "False"
 
 
 class Release(Base):
@@ -222,3 +226,45 @@ class Package(Base):
     ubuntu = Column(String)
     debian = Column(String)
     statuses = relationship("Status", cascade="all, delete-orphan")
+
+
+class BaseFilterQuery(Query):
+    __set_default_filters = True
+
+    def without_default_filters(self):
+        base_filter_query = self._clone()
+        base_filter_query.__set_default_filters = False
+
+        return base_filter_query
+
+    def get(self, ident):
+        # Override get() so that the flag is always checked in the
+        # DB as opposed to pulling from the identity map. - this is optional.
+        return Query.get(self.populate_existing(), ident)
+
+    def __iter__(self):
+        return Query.__iter__(self.private())
+
+    def from_self(self, *ent):
+        # Override from_self() to automatically apply
+        # the criterion to.  this works with count() and
+        # others.
+        return Query.from_self(self.private(), *ent)
+
+    def private(self):
+        if not self.__set_default_filters:
+            return self
+
+        # Fetch the model name and column list
+        # apply model-specific base filters
+        mapper_zero = self._mapper_zero()
+
+        if mapper_zero:
+            model = mapper_zero.class_
+
+            if hasattr(model, "_base_filters"):
+                return self.enable_assertions(False).filter(
+                    model._base_filters()
+                )
+
+        return self

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -228,6 +228,7 @@ class NoticeSchema(Schema):
     references = List(String())
     published = ParsedDateTime(required=True)
     details = String(allow_none=True, data_key="description")
+    is_hidden = Boolean(required=False)
     release_packages = Dict(
         keys=ReleaseCodename(),
         values=List(Nested(NoticePackage), required=True),
@@ -258,6 +259,16 @@ class NoticesAPISchema(Schema):
     total_results = Int()
 
 
+NoticeParameters = {
+    "is_hidden": Boolean(
+        description=(
+            "True or False if you want to select hidden notices. "
+            "Default is False."
+        ),
+        allow_none=True,
+    ),
+}
+
 NoticesParameters = {
     "details": String(
         description=(
@@ -284,6 +295,13 @@ NoticesParameters = {
         description=(
             "Select order: choose `oldest` for ASC order; "
             "leave empty for DESC order"
+        ),
+        allow_none=True,
+    ),
+    "is_hidden": Boolean(
+        description=(
+            "True or False if you want to select hidden notices. "
+            "Default is False."
         ),
         allow_none=True,
     ),

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -260,7 +260,7 @@ class NoticesAPISchema(Schema):
 
 
 NoticeParameters = {
-    "is_hidden": Boolean(
+    "show_hidden": Boolean(
         description=(
             "True or False if you want to select hidden notices. "
             "Default is False."
@@ -298,7 +298,7 @@ NoticesParameters = {
         ),
         allow_none=True,
     ),
-    "is_hidden": Boolean(
+    "show_hidden": Boolean(
         description=(
             "True or False if you want to select hidden notices. "
             "Default is False."

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -368,7 +368,7 @@ def delete_cve(cve_id):
 def get_notice(notice_id, **kwargs):
     notice_query = db_session.query(Notice)
 
-    if kwargs.get("is_hidden", False):
+    if kwargs.get("show_hidden", False):
         notice_query = notice_query.without_default_filters()
 
     notice = notice_query.filter(Notice.id == notice_id).one_or_none()


### PR DESCRIPTION
## Done

Add default filter to model and id_hidden to USN

## QA
- Have a database
- `docker-compose up -d` and `dotrun`
- USN-4417-2 is a hidden USN

Check fetch all Notices endpoint:
- Browse to http://0.0.0.0:8030/security/notices.json?is_hidden=false&details=USN-4417-2 -> returns 0 notices
- Browse to http://0.0.0.0:8030/security/notices.json?is_hidden=true&details=USN-4417-2 -> return 1 notice

Check fetch single Notices endpoint:
- Browse to http://0.0.0.0:8030/security/notices/USN-4417-2.json?is_hidden=false -> returns 404
- Browse to http://0.0.0.0:8030/security/notices/USN-4417-2.json?is_hidden=true -> return 200

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu-com-security-api/issues/34
Fixes https://github.com/canonical-web-and-design/ubuntu-com-security-api/issues/31