### PR TITLE
Detailed relations return

### DIFF
--- a/tests/alchemy_mock_data.py
+++ b/tests/alchemy_mock_data.py
@@ -107,14 +107,18 @@ notice_data = [
     (
         [
             mock.call.query(Notice),
-            mock.call.filter(Notice.id == "USN-0000-00"),
+            mock.call.filter(
+                Notice.is_hidden == "False", Notice.id == "USN-0000-00"
+            ),
         ],
         [],
     ),
     (
         [
             mock.call.query(Notice),
-            mock.call.filter(Notice.id == "USN-0000-01"),
+            mock.call.filter(
+                Notice.is_hidden == "False", Notice.id == "USN-0000-01"
+            ),
         ],
         [
             Notice(

--- a/tests/fixtures/CVE-0000-0001.json
+++ b/tests/fixtures/CVE-0000-0001.json
@@ -4,10 +4,11 @@
    "description": null,
    "id":"CVE-0000-0001",
    "notes": null,
-   "notices":[
+   "notices_ids":[
       "USN-9999-01",
       "USN-9999-02"
    ],
+   "notices": [{"id":  "USN-9999-01"}, {"id": "USN-9999-02"}],
    "packages":[
       {
          "debian":"https://tracker.debian.org/pkg/test_package",

--- a/tests/fixtures/USN-0000-01.json
+++ b/tests/fixtures/USN-0000-01.json
@@ -1,13 +1,14 @@
 {
-   "cves":[
-      "CVE-9999-0003",
-      "CVE-9999-0004"
-   ],
-   "id":"USN-0000-01",
-   "description": "This is the description",
-   "instructions": "These are the instructions",
-   "published": "2020-12-01 12:42:54",
-   "references": [],
+    "cves_ids": [
+        "CVE-9999-0003",
+        "CVE-9999-0004"
+    ],
+    "cves": [{"id": "CVE-9999-0003"}, {"id": "CVE-9999-0004"}],
+    "id": "USN-0000-01",
+    "description": "This is the description",
+    "instructions": "These are the instructions",
+    "published": "2020-12-01 12:42:54",
+    "references": [],
     "release_packages": {
         "bionic": [
             {

--- a/tests/fixtures/USN-0000-03.json
+++ b/tests/fixtures/USN-0000-03.json
@@ -1,7 +1,7 @@
 {
    "cves":[
-      "CVE-9999-0003",
-      "CVE-9999-0004"
+     "CVE-9999-0003",
+     "CVE-9999-0004"
    ],
    "id":"USN-0000-03",
    "description": "This is the description",

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -90,13 +90,13 @@ class TestRoutes(unittest.TestCase):
 
     def test_create_usn(self):
         notice = get_fixture("USN-0000-02")
-        response = self.client.post("/security/notices", json=notice)
+        response = self.client.post("/security/notices.json", json=notice)
 
         assert response.status_code == 200
 
     def test_create_usn_returns_422_for_non_unique_id(self):
         notice = get_fixture("USN-0000-01")
-        response = self.client.post("/security/notices", json=notice)
+        response = self.client.post("/security/notices.json", json=notice)
 
         assert response.status_code == 422
         assert "'USN-0000-01' already exists" in response.json["errors"]
@@ -105,7 +105,7 @@ class TestRoutes(unittest.TestCase):
         notice = get_fixture("USN-0000-02")
         notice["unknown"] = "field"
 
-        response = self.client.post("/security/notices", json=notice)
+        response = self.client.post("/security/notices.json", json=notice)
 
         assert response.status_code == 422
         assert "Unknown field." in response.json["errors"]
@@ -115,7 +115,7 @@ class TestRoutes(unittest.TestCase):
         notice["instructions"] = "Instructions were updated!"
 
         response = self.client.put(
-            "/security/notices/USN-0000-03", json=notice
+            "/security/notices/USN-0000-03.json", json=notice
         )
 
         assert response.status_code == 200
@@ -124,7 +124,7 @@ class TestRoutes(unittest.TestCase):
         notice = get_fixture("USN-0000-03")
 
         response = self.client.put(
-            "/security/notices/USN-0000-02", json=notice
+            "/security/notices/USN-0000-02.json", json=notice
         )
 
         assert response.status_code == 404
@@ -134,26 +134,26 @@ class TestRoutes(unittest.TestCase):
         notice["unknown"] = "field"
 
         response = self.client.put(
-            "/security/notices/USN-0000-03", json=notice
+            "/security/notices/USN-0000-03.json", json=notice
         )
 
         assert response.status_code == 422
         assert "Unknown field." in response.json["errors"]
 
     def test_delete_usn_returns_404_for_non_existing_usn(self):
-        response = self.client.delete("/security/notices/USN-0000-02")
+        response = self.client.delete("/security/notices/USN-0000-02.json")
 
         assert response.status_code == 404
 
     def test_delete_usn(self):
-        response = self.client.delete("/security/notices/USN-0000-04")
+        response = self.client.delete("/security/notices/USN-0000-04.json")
 
         assert response.status_code == 200
 
     def test_bulk_upsert_cves_returns_422_for_invalid_cve(self):
         cve = get_fixture("CVE-9999-0000")
         cve["hello"] = "world"
-        response = self.client.put("/security/cves", json=[cve])
+        response = self.client.put("/security/cves.json", json=[cve])
 
         assert response.status_code == 422
         assert "Unknown field." in response.json["errors"]
@@ -169,7 +169,7 @@ class TestRoutes(unittest.TestCase):
         assert response.status_code == 404
 
         response = self.client.put(
-            "/security/cves",
+            "/security/cves.json",
             json=[
                 get_fixture("CVE-9999-0000"),
                 get_fixture("CVE-9999-0001"),
@@ -179,26 +179,26 @@ class TestRoutes(unittest.TestCase):
         assert response.status_code == 200
 
     def test_delete_non_existing_cve_returns_404(self):
-        response = self.client.delete("/security/cves/CVE-9999-0002")
+        response = self.client.delete("/security/cves/CVE-9999-0002.json")
 
         assert response.status_code == 404
 
     def test_delete_cve(self):
-        response = self.client.delete("/security/cves/CVE-9999-0000")
+        response = self.client.delete("/security/cves/CVE-9999-0000.json")
         assert response.status_code == 200
 
-        response = self.client.delete("/security/cves/CVE-9999-0001")
+        response = self.client.delete("/security/cves/CVE-9999-0001.json")
         assert response.status_code == 200
 
     def test_create_release(self):
         release = get_fixture("new-release")
-        response = self.client.post("/security/releases", json=release)
+        response = self.client.post("/security/releases.json", json=release)
 
         assert response.status_code == 200
 
     def test_create_existing_release_returns_422(self):
         release = get_fixture("hirsute")
-        response = self.client.post("/security/releases", json=release)
+        response = self.client.post("/security/releases.json", json=release)
 
         assert response.status_code == 422
         assert (
@@ -215,12 +215,12 @@ class TestRoutes(unittest.TestCase):
         )
 
     def test_delete_non_existing_release_returns_404(self):
-        response = self.client.delete("/security/releases/no-exist")
+        response = self.client.delete("/security/releases/no-exist.json")
 
         assert response.status_code == 404
 
     def test_delete_release(self):
-        response = self.client.delete("/security/releases/hirsute")
+        response = self.client.delete("/security/releases/hirsute.json")
 
         assert response.status_code == 200
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -50,7 +50,7 @@ class TestRoutes(unittest.TestCase):
 
         assert response.status_code == 200
         assert response.json["packages"] == expected_cve["packages"]
-        assert response.json["notices"] == expected_cve["notices"]
+        assert response.json["notices_ids"] == expected_cve["notices_ids"]
 
     def test_cves_returns_422_for_non_existing_package_name(self):
         response = self.client.get("/security/cves.json?package=no-exist")
@@ -80,7 +80,7 @@ class TestRoutes(unittest.TestCase):
         expected_notice = get_fixture("USN-0000-01")
 
         assert response.status_code == 200
-        assert response.json["cves"] == expected_notice["cves"]
+        assert response.json["cves_ids"] == expected_notice["cves_ids"]
 
     def test_usns_returns_422_for_non_existing_release(self):
         response = self.client.get("/security/notices.json?release=no-exist")

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -50,14 +50,14 @@ app.add_url_rule(
 )
 
 app.add_url_rule(
-    "/security/cves",
+    "/security/cves.json",
     view_func=bulk_upsert_cve,
     methods=["PUT"],
     provide_automatic_options=False,
 )
 
 app.add_url_rule(
-    "/security/cves/<cve_id>",
+    "/security/cves/<cve_id>.json",
     view_func=delete_cve,
     methods=["DELETE"],
     provide_automatic_options=False,
@@ -76,34 +76,34 @@ app.add_url_rule(
 )
 
 app.add_url_rule(
-    "/security/notices",
+    "/security/notices.json",
     view_func=create_notice,
     methods=["POST"],
     provide_automatic_options=False,
 )
 
 app.add_url_rule(
-    "/security/notices/<notice_id>",
+    "/security/notices/<notice_id>.json",
     view_func=update_notice,
     methods=["PUT"],
     provide_automatic_options=False,
 )
 
 app.add_url_rule(
-    "/security/notices/<notice_id>",
+    "/security/notices/<notice_id>.json",
     view_func=delete_notice,
     methods=["DELETE"],
     provide_automatic_options=False,
 )
 
 app.add_url_rule(
-    "/security/releases",
+    "/security/releases.json",
     view_func=create_release,
     methods=["POST"],
     provide_automatic_options=False,
 )
 app.add_url_rule(
-    "/security/releases/<codename>",
+    "/security/releases/<codename>.json",
     view_func=delete_release,
     methods=["DELETE"],
     provide_automatic_options=False,

--- a/webapp/database.py
+++ b/webapp/database.py
@@ -4,7 +4,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.orm import scoped_session, sessionmaker
 
-from webapp.models import Release, BaseFilterQuery
+from webapp.models import Release
 
 db_engine = create_engine(os.environ["DATABASE_URL"])
 db_session = scoped_session(
@@ -12,7 +12,6 @@ db_session = scoped_session(
         autocommit=False,
         autoflush=False,
         bind=db_engine,
-        query_cls=BaseFilterQuery,
     )
 )
 

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -247,16 +247,7 @@ class CreateNoticeImportSchema(NoticeImportSchema):
 
 class NoticeAPISchema(NoticeSchema):
     notice_type = String(data_key="type")
-    cves_ids = List(
-        String(validate=Regexp(r"(cve-|CVE-)\d{4}-\d{4,7}")), data_key="cves"
-    )
-
-
-class NoticesAPISchema(Schema):
-    notices = List(Nested(NoticeAPISchema))
-    offset = Int(allow_none=True)
-    limit = Int(allow_none=True)
-    total_results = Int()
+    cves_ids = List(String(validate=Regexp(r"(cve-|CVE-)\d{4}-\d{4,7}")))
 
 
 NoticeParameters = {
@@ -382,16 +373,40 @@ class CVEAPISchema(CVESchema):
     package_statuses = List(Nested(CvePackage), data_key="packages")
     notices_ids = List(
         String(validate=Regexp(r"(USN|LSN)-\d{1,5}-\d{1,2}")),
-        data_key="notices",
     )
 
 
-class CVEsAPISchema(Schema):
+class NoticeAPIDetailedSchema(NoticeAPISchema):
     cves = List(Nested(CVEAPISchema))
+
+
+class CVEAPIDetailedSchema(CVEAPISchema):
+    notices = List(Nested(NoticeAPISchema))
+
+
+class NoticesAPISchema(Schema):
+    notices = List(Nested(NoticeAPIDetailedSchema))
     offset = Int(allow_none=True)
     limit = Int(allow_none=True)
     total_results = Int()
 
+
+class CVEsAPISchema(Schema):
+    cves = List(Nested(CVEAPIDetailedSchema))
+    offset = Int(allow_none=True)
+    limit = Int(allow_none=True)
+    total_results = Int()
+
+
+CVEParameter = {
+    "show_hidden": Boolean(
+        description=(
+            "True or False if you want to select hidden notices. "
+            "Default is False."
+        ),
+        allow_none=True,
+    ),
+}
 
 CVEsParameters = {
     "q": String(
@@ -435,6 +450,13 @@ CVEsParameters = {
         description=(
             "Select order: choose `oldest` for ASC order; "
             "leave empty for DESC order"
+        ),
+        allow_none=True,
+    ),
+    "show_hidden": Boolean(
+        description=(
+            "True or False if you want to select hidden notices. "
+            "Default is False."
         ),
         allow_none=True,
     ),

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -43,7 +43,7 @@ class ReleaseCodename(String):
     }
 
     def _deserialize(self, value, attr, data, **kwargs):
-        if value not in release_codenames:
+        if value != "" and value not in release_codenames:
             raise self.make_error("unrecognised_codename", input=value)
 
         return super()._deserialize(value, attr, data, **kwargs)
@@ -67,7 +67,7 @@ class StatusStatuses(String):
     }
 
     def _deserialize(self, value, attr, data, **kwargs):
-        if value not in status_statuses:
+        if value != "" and value not in status_statuses:
             raise self.make_error("unrecognised_status", input=value)
 
         return super()._deserialize(value, attr, data, **kwargs)
@@ -189,7 +189,7 @@ class PackageName(String):
 
 class Pocket(String):
     default_error_messages = {
-        "unrecognised_component": (
+        "unrecognised_pocket": (
             "Pocket must be one of "
             "'security', 'updates', 'esm-infra', 'esm-apps'"
         )

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -268,6 +268,7 @@ NoticesParameters = {
         ),
         allow_none=True,
     ),
+    "cve_id": String(allow_none=True),
     "release": ReleaseCodename(
         enum=release_codenames,
         description="List of release codenames",

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -629,9 +629,7 @@ def _update_notice_object(notice, data):
     notice.published = data["published"]
     notice.references = data["references"]
     notice.instructions = data["instructions"]
-
-    if "is_hidden" in data:
-        notice.is_hidden = data["is_hidden"]
+    notice.is_hidden = data.get("is_hidden", False)
 
     notice.releases = [
         db_session.query(Release).get(codename)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -398,6 +398,7 @@ def get_notice(notice_id, **kwargs):
 @use_kwargs(NoticesParameters, location="query")
 def get_notices(**kwargs):
     details = kwargs.get("details")
+    cve_id = kwargs.get("cve_id")
     release = kwargs.get("release")
     limit = kwargs.get("limit", 20)
     offset = kwargs.get("offset", 0)
@@ -409,6 +410,9 @@ def get_notices(**kwargs):
 
     if not kwargs.get("show_hidden", False):
         notices_query = notices_query.filter(Notice.is_hidden == "False")
+
+    if cve_id:
+        notices_query = notices_query.filter(Notice.cves.any(CVE.id == cve_id))
 
     if release:
         notices_query = notices_query.join(Release, Notice.releases).filter(

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -11,8 +11,6 @@ from webapp.auth import authorization_required
 from webapp.database import db_session, status_statuses
 from webapp.models import CVE, Notice, Release, Status, Package
 from webapp.schemas import (
-    CVEAPISchema,
-    NoticeAPISchema,
     CVEsAPISchema,
     CVEsParameters,
     NoticesParameters,
@@ -24,12 +22,18 @@ from webapp.schemas import (
     CVEImportSchema,
     ReleaseSchema,
     NoticeParameters,
+    CVEParameter,
+    CVEAPIDetailedSchema,
+    NoticeAPIDetailedSchema,
 )
 
 
-@marshal_with(CVEAPISchema, code=200)
+@marshal_with(CVEAPIDetailedSchema, code=200)
 @marshal_with(MessageSchema, code=404)
-def get_cve(cve_id):
+@use_kwargs(CVEParameter, location="query")
+def get_cve(cve_id, **kwargs):
+    show_hidden = kwargs.get("show_hidden", False)
+
     cve = db_session.query(CVE).filter(CVE.id == cve_id).one_or_none()
 
     if not cve:
@@ -37,6 +41,8 @@ def get_cve(cve_id):
             jsonify({"message": f"CVE with id '{cve_id}' does not exist"}),
             404,
         )
+
+    cve.notices = cve.get_filtered_notices(show_hidden)
 
     return cve
 
@@ -54,6 +60,7 @@ def get_cves(**kwargs):
     versions = kwargs.get("version")
     statuses = kwargs.get("status")
     order_by = kwargs.get("order")
+    show_hidden = kwargs.get("show_hidden", False)
 
     clean_versions = _get_clean_versions(statuses, versions)
     clean_statuses = _get_clean_statuses(statuses, versions)
@@ -204,6 +211,8 @@ def get_cves(**kwargs):
                 statuses.append(status)
 
         cve.statuses = statuses
+        cve.notices = cve.get_filtered_notices(show_hidden)
+
         cves.append(cve)
 
     return {
@@ -361,15 +370,15 @@ def delete_cve(cve_id):
     )
 
 
-@marshal_with(NoticeAPISchema, code=200)
+@marshal_with(NoticeAPIDetailedSchema, code=200)
 @marshal_with(MessageSchema, code=404)
 @marshal_with(MessageWithErrorsSchema, code=404)
 @use_kwargs(NoticeParameters, location="query")
 def get_notice(notice_id, **kwargs):
     notice_query = db_session.query(Notice)
 
-    if kwargs.get("show_hidden", False):
-        notice_query = notice_query.without_default_filters()
+    if not kwargs.get("show_hidden", False):
+        notice_query = notice_query.filter(Notice.is_hidden == "False")
 
     notice = notice_query.filter(Notice.id == notice_id).one_or_none()
 
@@ -398,8 +407,8 @@ def get_notices(**kwargs):
         Notice, func.count("*").over().label("total")
     )
 
-    if kwargs.get("show_hidden", False):
-        notices_query = notices_query.without_default_filters()
+    if not kwargs.get("show_hidden", False):
+        notices_query = notices_query.filter(Notice.is_hidden == "False")
 
     if release:
         notices_query = notices_query.join(Release, Notice.releases).filter(


### PR DESCRIPTION
## Done

1) Delete `BaseFilterQuery` class, as it makes endpoints untestable with `sqlalchemy_mock`. For the API it's not a big deal, adding the filters manually makes little difference.  
2) Add `show_hidden` parameter, so CVEs can hide/reveal hidden USNs.
3) Make `cve.notices` and `notice.cves` return full payload of `notices` and `cves`. `cve.notices_ids` and `notice.cves_ids` return just arrays of ids.
4) Add suffix .json to all endpoints
5) Validation bug fixes
6) Add `cve_id` filter for notices.json

## QA
- Have a database and fetch changes.
- Test public notice returns 200:
http://0.0.0.0:8030/security/notices/USN-4417-1.json
- Test private notices returns 404:
http://0.0.0.0:8030/security/notices/USN-4417-2.json
- Test private notices returns 404 with flag:
http://0.0.0.0:8030/security/notices/USN-4417-2.json?show_hidden=false
- Test show private notices 200:
http://0.0.0.0:8030/security/notices/USN-4417-2.json?show_hidden=true
- Test show cve returns only public usns (`cve.notices_ids`): 
http://0.0.0.0:8030/security/cves/CVE-2020-12402.json
- Test show cve returns only public usns with flag (`cve.notices_ids`): http://0.0.0.0:8030/security/cves/CVE-2020-12402.json?show_hidden=False
- Test show cve returns all usns (`cve.notices_ids`): 
http://0.0.0.0:8030/security/cves/CVE-2020-12402.json?show_hidden=true

## Issue / Card

Fixes #37 