### PR TITLE
Fix docs and spec URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # security.ubuntu.com
 The API for CVEs and USNs data.
 
-To check the API documentation go to https://security.ubuntu.com/docs
+To check the API documentation go to https://ubuntu.com/security/api/docs
 
 # Local development
 The simplest way to run the API locally is using dotrun:
@@ -15,6 +15,6 @@ Once the server has started, you can visit http://0.0.0.0:8030 in your browser.
 
 After you close the server with `<ctrl>+c` you should run `docker-compose down` to stop the database.
 
-Documentation spec is available at http://0.0.0.0:8030/spec
+Documentation spec is available at http://0.0.0.0:8030/security/api/spec.json
 
-Documentation is available at http://0.0.0.0:8030/docs
+Documentation is available at http://0.0.0.0:8030/security/api/docs


### PR DESCRIPTION
## Done

Changed invalid URLs with the ones that should be.

Invalid URLs in README:
- https://security.ubuntu.com/docs
- http://0.0.0.0:8030/spec
- http://0.0.0.0:8030/docs

Valid URLs:
- https://ubuntu.com/security/api/docs
- http://0.0.0.0:8030/security/api/spec.json
- http://0.0.0.0:8030/security/api/docs



