### PR TITLE
Updated action to install dotrun @main

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,9 +53,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install dotrun
-        run: |
-          sudo snap install dotrun
-          sudo chown root:root /
+        uses: canonical/install-dotrun@main
 
       - name: Install dependencies
         run: /snap/bin/dotrun install


### PR DESCRIPTION
## Done

- Updated action to install dotrun @main 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Run through the following [QA steps](https://canonical-web-and-design.github
.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu-com-security-api/issues/62
