### PR TITLE
Increase memory to 512MiB per pod

### DIFF
--- a/konf/raw-site.yaml
+++ b/konf/raw-site.yaml
@@ -84,4 +84,4 @@ spec:
 
           resources:
             limits:
-              memory: 256Mi
+              memory: 512Mi


### PR DESCRIPTION
To alleviate memory pressure from database queries, as detailed in https://portal.admin.canonical.com/C135032