### PR TITLE
Made notice and cve queries case insensitive

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -36,7 +36,7 @@ from webapp.schemas import (
 def get_cve(cve_id, **kwargs):
     show_hidden = kwargs.get("show_hidden", False)
 
-    cve = db_session.query(CVE).get(cve_id.upper())
+    cve = db_session.query(CVE).filter(CVE.id == cve_id.upper()).one_or_none()
 
     if not cve:
         return make_response(
@@ -356,7 +356,7 @@ def bulk_upsert_cve(*args, **kwargs):
 @marshal_with(MessageSchema, code=200)
 @marshal_with(MessageSchema, code=404)
 def delete_cve(cve_id):
-    cve = db_session.query(CVE).get(cve_id.upper())
+    cve = db_session.query(CVE).filter(CVE.id == cve_id.upper()).one_or_none()
 
     if not cve:
         return make_response(

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -36,7 +36,7 @@ from webapp.schemas import (
 def get_cve(cve_id, **kwargs):
     show_hidden = kwargs.get("show_hidden", False)
 
-    cve = db_session.query(CVE).filter(CVE.id == cve_id).one_or_none()
+    cve = db_session.query(CVE).get(cve_id.upper())
 
     if not cve:
         return make_response(
@@ -382,7 +382,7 @@ def get_notice(notice_id, **kwargs):
     if not kwargs.get("show_hidden", False):
         notice_query = notice_query.filter(Notice.is_hidden == "False")
 
-    notice = notice_query.filter(Notice.id == notice_id).one_or_none()
+    notice = notice_query.filter(Notice.id == notice_id.upper()).one_or_none()
 
     if not notice:
         return make_response(

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -253,7 +253,7 @@ def bulk_upsert_cve(*args, **kwargs):
 
     for data in cves_data:
         update_cve = False
-        cve = db_session.query(CVE).filter(CVE.id == data["id"]).one_or_none()
+        cve = db_session.query(CVE).get(data["id"].upper())
 
         if cve is None:
             update_cve = True
@@ -356,7 +356,7 @@ def bulk_upsert_cve(*args, **kwargs):
 @marshal_with(MessageSchema, code=200)
 @marshal_with(MessageSchema, code=404)
 def delete_cve(cve_id):
-    cve = db_session.query(CVE).filter(CVE.id == cve_id).one_or_none()
+    cve = db_session.query(CVE).get(cve_id.upper())
 
     if not cve:
         return make_response(


### PR DESCRIPTION
## Done

- Made notice and cve queries case insensitive

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030
- For CVE visit: http://0.0.0.0:8030/security/cves/cve-2018-19662.json
   - change the letter case for the cve id (in this case `cve-2018-19662`) and run again
   - see that the result is unchanged 
- For USN visit: http://0.0.0.0:8030/security/notices/usn-4189-2.json 
   -  change the letter case for the usn id (`usn-4189-2`) and run again
   - see that the results are unchanged 
- Note: You can also pick a random cve or usn to QA this with


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu-com-security-api/issues/60
