### PR TITLE
Add get releases endpoint

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -19,7 +19,7 @@ from webapp.views import (
     delete_release,
     update_release,
     get_release,
-    get_releases
+    get_releases,
 )
 
 app = FlaskBase(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -19,6 +19,7 @@ from webapp.views import (
     delete_release,
     update_release,
     get_release,
+    get_releases
 )
 
 app = FlaskBase(
@@ -106,6 +107,12 @@ app.add_url_rule(
 )
 app.add_url_rule(
     "/security/releases.json",
+    view_func=get_releases,
+    methods=["GET"],
+    provide_automatic_options=False,
+)
+app.add_url_rule(
+    "/security/releases.json",
     view_func=create_release,
     methods=["POST"],
     provide_automatic_options=False,
@@ -134,6 +141,7 @@ views_to_register_in_docs = [
     update_notice,
     delete_notice,
     get_release,
+    get_releases,
     create_release,
     update_release,
     delete_release,

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -328,8 +328,10 @@ class UpdateReleaseSchema(Schema):
 class ReleaseAPISchema(ReleaseSchema):
     support_tag = String()
 
+
 class ReleasesAPISchema(Schema):
     releases = List(Nested(ReleaseAPISchema))
+
 
 # CVEs
 # --

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -328,6 +328,8 @@ class UpdateReleaseSchema(Schema):
 class ReleaseAPISchema(ReleaseSchema):
     support_tag = String()
 
+class ReleasesAPISchema(Schema):
+    releases = List(Nested(ReleaseAPISchema))
 
 # CVEs
 # --

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -26,6 +26,7 @@ from webapp.schemas import (
     CVEAPIDetailedSchema,
     NoticeAPIDetailedSchema,
     ReleaseAPISchema,
+    ReleasesAPISchema,
     UpdateReleaseSchema,
 )
 
@@ -526,6 +527,25 @@ def get_release(release_codename):
         )
 
     return release
+
+
+@marshal_with(ReleasesAPISchema, code=200)
+@marshal_with(MessageSchema, code=404)
+def get_releases():
+    releases = (
+        db_session.query(Release)
+        .order_by(desc(Release.release_date))
+        .filter(
+            or_(
+                Release.codename == "upstream",
+                Release.support_expires > datetime.now(),
+                Release.esm_expires > datetime.now(),
+            )
+        )
+        .all()
+    )
+    
+    return {"releases": releases}
 
 
 @authorization_required

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -544,7 +544,7 @@ def get_releases():
         )
         .all()
     )
-    
+ 
     return {"releases": releases}
 
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -544,7 +544,7 @@ def get_releases():
         )
         .all()
     )
- 
+
     return {"releases": releases}
 
 


### PR DESCRIPTION
## Done

- Added endpoint for getting all releases where neither esm or support has expired and includes release named `upstream`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/security/api/docs
- Request url: http://0.0.0.0:8030/security/releases.json
- Curl: `curl -X GET "http://0.0.0.0:8030/security/releases.json" -H "accept: application/json"`
- Check that either of the above methods return all releases with above criteria 


## Issue / Card

Fixes https://github.com/canonical-web-and-design/master-epics/issues/398
