### PR TITLE
Set up DB management

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@ To check the API documentation go to https://ubuntu.com/security/api/docs
 # Local development
 The simplest way to run the API locally is using dotrun:
 
-```
-docker-compose up -d
+``` bash
 dotrun
+```
+
+It's quite likely you might also want to put some sample data in the database:
+
+``` bash
+# In another terminal window, while the DB is running
+dotrun exec scripts/generate-sample-security-data.py
 ```
 
 Once the server has started, you can visit http://0.0.0.0:8030 in your browser.
@@ -18,3 +24,4 @@ After you close the server with `<ctrl>+c` you should run `docker-compose down` 
 Documentation spec is available at http://0.0.0.0:8030/security/api/spec.json
 
 Documentation is available at http://0.0.0.0:8030/security/api/docs
+

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,2 @@
+[alembic]
+script_location = webapp/alembic

--- a/entrypoint
+++ b/entrypoint
@@ -1,10 +1,22 @@
 #! /usr/bin/env bash
 
 set -e
-RUN_COMMAND="talisker.gunicorn.gevent webapp.app:app --bind $1 --worker-class gevent --name talisker-`hostname`"
 
+
+# Extra arguments for debug mode
 if [ "${FLASK_DEBUG}" = true ] || [ "${FLASK_DEBUG}" = 1 ]; then
-    RUN_COMMAND="${RUN_COMMAND} --reload --log-level debug --timeout 9999"
+    DEBUG_ARGS="--reload --log-level debug --timeout 9999"
+else
+    DEBUG_ARGS=""
 fi
 
-${RUN_COMMAND}
+
+# Provision database
+# ===
+alembic upgrade head
+
+
+# Start server
+# ===
+talisker.gunicorn.gevent webapp.app:app --bind $1 --worker-class gevent --name talisker-`hostname` ${DEBUG_ARGS}
+

--- a/scripts/generate-sample-security-data.py
+++ b/scripts/generate-sample-security-data.py
@@ -1,0 +1,79 @@
+#! /usr/bin/env python3
+
+import os
+import sys
+
+sys.path.append(os.getcwd())
+
+from datetime import datetime
+
+from webapp.models import Notice, Release, Status, CVE, Package
+from webapp.database import db_session
+
+
+release = Release(
+    codename="some release",
+    name="00.00",
+    version="0.0.0",
+    lts=True,
+    development=False,
+    release_date=datetime.now(),
+    esm_expires=datetime.now(),
+    support_expires=datetime.now()
+)
+db_session.add(release)
+
+package = Package(
+    name="some package",
+    source="",
+    launchpad="",
+    ubuntu="",
+    debian=""
+)
+db_session.add(package)
+
+
+for usn_num in range(9999):
+    cves = []
+
+    for cve_num in range(5):
+        cve = CVE(
+            id=f"CVE-{usn_num}-{cve_num}",
+            published=datetime.now(),
+            description="",
+            ubuntu_description="",
+            notes={},
+            priority="unknown",
+            cvss3=2.3,
+            mitigation="",
+            references={},
+            patches={},
+            tags={},
+            bugs={},
+            status="active"
+        )
+        db_session.add(cve)
+        cves.append(cve)
+
+        status = Status(
+            status="pending",
+            cve=cve,
+            package=package,
+            release=release
+        )
+        db_session.add(status)
+
+    notice = Notice(
+        id=f"USN-{usn_num:04d}",
+        is_hidden=False,
+        published=datetime.now(),
+        summary="",
+        details="",
+        instructions="",
+        releases=[release],
+        cves=cves
+    )
+    db_session.add(notice)
+
+db_session.commit()
+


### PR DESCRIPTION
This will configure this project to properly manage the database, taking over from ubuntu.com:

- Add alembic.ini so the `alembic` tool can manage the database
- Run `alembic upgrade head` in `./entrypoint` to ensure the DB is provisioned to the latest state every time
  - This will match the state of the database with the migration scripts in `webapp/alembic/versions`, which should be the exact same set of migrations as are in ubuntu.com, hence it shouldn't conflict with the database that ubuntu.com manages

QA
--

### 1. Check provisioning can take over an existing database

First, run [the ubuntu.com project](https://github.com/canonical-web-and-design/ubuntu.com/) with `dotrun`, or otherwise get its database running and provisioned.

Now, inside the folder for this branch, run `dotrun install && dotrun exec alembic upgrade head`. This should attempt to provision the existing ubuntu.com database (running on `localhost:5432`, as per the `DATABASE_URL` in `.env`), which should succeed without any problems:

``` bash
$ dotrun exec alembic upgrade head

[ $ alembic upgrade head ] ( virtualenv `.venv` )


$
```

### 2. Check the database can be provisioned and populated from scratch

``` bash
dotrun clean
dotrun
```

This should successfully start the site.

Now generate the dummy data: In a new terminal window, run `dotrun exec scripts/generate-sample-security-data.py` (as it says in the README.md).

Once this is finished, go to http://localhost:8030/security/cves.json or http://localhost:8030/security/notices.json and see all the awesome data.