### PR TITLE
Add related notices to notice payload

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ psycopg2-binary==2.9.3
 SQLAlchemy==1.4.29
 webargs==6.1.1
 black==21.12b0
+sortedcontainers==2.4.0

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -153,6 +153,35 @@ class Notice(Base):
 
         return ""
 
+    @hybrid_property
+    def package_list(self):
+        if not self.release_packages:
+            return []
+
+        package_list = []
+        for codename, packages in self.release_packages.items():
+            for package in packages:
+                package_list.append(package["name"])
+
+        return set(sorted(package_list))
+
+    @hybrid_property
+    def related_notices(self):
+        related_notices_ids = [self.id]
+        related_notices = []
+        for cve in self.cves:
+            for notice in cve.notices:
+                if notice.id not in related_notices_ids:
+                    related_notices.append(
+                        {
+                            "id": notice.id,
+                            "package_list": ", ".join(notice.package_list),
+                        }
+                    )
+                    related_notices_ids.append(notice.id)
+
+        return related_notices
+
 
 class Release(Base):
     __tablename__ = "release"

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -167,18 +167,18 @@ class Notice(Base):
 
     @hybrid_property
     def related_notices(self):
-        related_notices_ids = [self.id]
+        seen_notices_ids = [self.id]
         related_notices = []
         for cve in self.cves:
             for notice in cve.notices:
-                if notice.id not in related_notices_ids:
+                if notice.id not in seen_notices_ids:
                     related_notices.append(
                         {
                             "id": notice.id,
                             "packages": ", ".join(notice.packages),
                         }
                     )
-                    related_notices_ids.append(notice.id)
+                    seen_notices_ids.append(notice.id)
 
         return related_notices
 

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -154,13 +154,13 @@ class Notice(Base):
         return ""
 
     @hybrid_property
-    def package_list(self):
+    def packages(self):
         if not self.release_packages:
             return []
 
         package_list = []
-        for codename, packages in self.release_packages.items():
-            for package in packages:
+        for codename, current_packages in self.release_packages.items():
+            for package in current_packages:
                 package_list.append(package["name"])
 
         return set(sorted(package_list))
@@ -175,7 +175,7 @@ class Notice(Base):
                     related_notices.append(
                         {
                             "id": notice.id,
-                            "package_list": ", ".join(notice.package_list),
+                            "packages": ", ".join(notice.packages),
                         }
                     )
                     related_notices_ids.append(notice.id)

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -395,7 +395,7 @@ class CVEAPISchema(CVESchema):
 
 class RelatedNoticesSchema(Schema):
     id = String()
-    package_list = String()
+    packages = String()
 
 
 class NoticeAPIDetailedSchema(NoticeAPISchema):

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -393,8 +393,14 @@ class CVEAPISchema(CVESchema):
     )
 
 
+class RelatedNoticesSchema(Schema):
+    id = String()
+    package_list = String()
+
+
 class NoticeAPIDetailedSchema(NoticeAPISchema):
     cves = List(Nested(CVEAPISchema))
+    related_notices = List(Nested(RelatedNoticesSchema))
 
 
 class CVEAPIDetailedSchema(CVEAPISchema):

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -6,7 +6,6 @@ from flask_apispec import marshal_with, use_kwargs
 from sqlalchemy import desc, or_, func, and_, case, asc
 from sqlalchemy.exc import DataError, IntegrityError
 from sqlalchemy.orm import contains_eager
-from sortedcontainers import SortedDict
 
 from webapp.auth import authorization_required
 from webapp.database import db_session, status_statuses

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -394,44 +394,6 @@ def get_notice(notice_id, **kwargs):
             404,
         )
 
-    releases = {
-        release.codename: release.version
-        for release in db_session.query(Release).all()
-    }
-
-    package_descriptions = {}
-    package_versions = {}
-    release_packages = SortedDict()
-
-    if notice.release_packages:
-        for codename, pkgs in notice.release_packages.items():
-            release_version = releases[codename]
-            release_packages[release_version] = {}
-            for package in pkgs:
-                if not package.get("is_visible", True):
-                    continue
-
-                name = package["name"]
-                if not package["is_source"]:
-                    release_packages[release_version][name] = package
-                    continue
-
-                if notice.notice_type == "LSN":
-                    if name not in package_descriptions:
-                        package_versions[name] = []
-
-                    package_versions[name].append(package["version"])
-                    versions = ", >= ".join(package_versions[name])
-                    description = (
-                        f"{package['description']} - " f"(>= {versions})"
-                    )
-                    package_descriptions[name] = description
-
-                    continue
-
-                if name not in package_descriptions:
-                    package_descriptions[name] = package["description"]
-
     return notice
 
 


### PR DESCRIPTION
## Done

- Added related notices to notice payload 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Query any notice and see that "related_notices" is included if there are any or that is an empty array if not
- Example:  http://0.0.0.0:8030/security/notices/USN-3537-2.json (supposed to have populated related notices array)
                    http://0.0.0.0:8030/security/notices/USN-3235-1.json (no related notices, empty array)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu-com-security-api/issues/79
