### PR TITLE
Add test for GET /security/cves.json endpoint

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 PORT=8030
+DEVEL=true
 FLASK_APP=webapp.app
 FLASK_DEBUG=true
 SECRET_KEY=local_development_fake_key

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -94,6 +94,17 @@ class TestRoutes(unittest.TestCase):
 
         assert response.status_code == 200
 
+    def test_cves(self):
+        """
+        Check /security/cves.json returns a list with the expected CVE
+        """
+
+        response = self.client.get("/security/cves.json")
+
+        assert response.status_code == 200
+        assert len(response.json["cves"]) == 1
+        assert response.json["cves"][0]["id"] == "CVE-1111-0001"
+
     def test_cve_not_exists(self):
         response = self.client.get("/security/cves/CVE-0000-0000.json")
 


### PR DESCRIPTION
- Give talisker output pretty colours in development
- Add CVE list endpoint test

I wrote this because it occurred to me that https://github.com/canonical-web-and-design/ubuntu-com-security-api/pull/85#issuecomment-1072206182 should have been picked up by a test, but wasn't. Although, I actually tried to break this test by reverting the code to that state, and it didn't break :( that's because for some reason the mocked test data doesn't seem to run into the case that leads to that particular error. I tried to track down what data I could create that would have caused that error, but I couldn't work it out. It's a shame, but I don't think it's worth spending a lot of time on since it's just one edge-case that may never crop up again.

## QA

Check tests pass