### PR TITLE
Update releases endpoint and notice payload

### DIFF
--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -339,9 +339,16 @@ class RelatedNoticesSchema(Schema):
     packages = String()
 
 
+class NoticeReleasesSchema(Schema):
+    codename = String()
+    version = String()
+    support_tag = String()
+
+
 class NoticeAPIDetailedSchema(NoticeAPISchema):
     cves = List(Nested(CVEAPISchema))
     related_notices = List(Nested(RelatedNoticesSchema))
+    releases = List(Nested(NoticeReleasesSchema))
 
 
 class CVEAPIDetailedSchema(CVEAPISchema):

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -532,17 +532,7 @@ def get_release(release_codename):
 @marshal_with(ReleasesAPISchema, code=200)
 @marshal_with(MessageSchema, code=404)
 def get_releases():
-    releases = (
-        Release.query.order_by(desc(Release.release_date))
-        .filter(
-            or_(
-                Release.codename == "upstream",
-                Release.support_expires > datetime.now(),
-                Release.esm_expires > datetime.now(),
-            )
-        )
-        .all()
-    )
+    releases = Release.query.order_by(desc(Release.release_date))
 
     return {"releases": releases}
 


### PR DESCRIPTION
## Done

- Update releases endpoint to remove filtering
- Add related releases to notice payload 
Note: This change will break the existing cve view on ubuntu. I will be making a pr to fix that, but this pr must be merged only when that one is reviewed and ready to go
_**You must be running this branch in order to qa [#11380](https://github.com/canonical-web-and-design/ubuntu.com/pull/11380) and [#1136](https://github.com/canonical-web-and-design/ubuntu.com/pull/11369)**_

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/security/releases.json
- Use the releases endpoint above and see that all releases are returned
- View the site locally in your web browser at: http://0.0.0.0:8030/security/notices/USN-4147-1.json
- Visit above endpoint and see that releases are listed
- You can also swap the notice id for any other notice and make sure it qas just the same 



## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu-com-security-api/issues/88
