### PR TITLE
Add view to api docs

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -179,6 +179,7 @@ views_to_register_in_docs = [
     bulk_upsert_cve,
     delete_cve,
     get_page_notices,
+    get_flat_notices,
     get_notice,
     get_notices,
     get_notice_v2,


### PR DESCRIPTION
## Done

- Added new endpoint to api docs  

## QA

- View the site locally in your web browser at: http://0.0.0.0:8030/security/api/docs#/
- See that the /security/flat/notices endpoint is listed 


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
