### PR TITLE
Remove notes query functionality

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1385,18 +1385,6 @@ class TestRoutes(BaseTestCase):
         )
         assert response.status_code == 200
 
-    def test_cves_query_notes(self):
-        """
-        Query text field should include notes
-        """
-        # Act
-        response = self.client.get("/security/cves.json?q=sql")
-
-        # Assert
-        assert response.status_code == 200
-        assert response.json["total_results"] == 1
-        assert len(response.json["cves"]) == 1
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -11,7 +11,7 @@ from flask import (
     stream_with_context,
 )
 from flask_apispec import marshal_with, use_kwargs
-from sqlalchemy import asc, case, desc, func, or_, text
+from sqlalchemy import asc, case, desc, func, or_
 from sqlalchemy.exc import DataError, IntegrityError
 from sqlalchemy.orm import Query, load_only, selectinload, aliased
 from webapp.auth import authorization_required


### PR DESCRIPTION
## Done

- Removed notes querying functionality 

## Rationale

The full-text search on notes subfields is using a raw SQL EXISTS clause with `json_array_elements`, which failed at runtime when the notes field was null or not a JSON array. I tested a fallback to guard against this, but the query still caused degraded performance and pagination issues. Since notes searches are rarely used and significantly impact performance, the filter has been removed to improve reliability and query speed.

## QA

- View the site locally in your web browser at: http://0.0.0.0:8030/security/cves.json?q=CVE-2022-19916&order=descending&sort_by=published 
- See that no errors are observed 

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
