### PR TITLE
feat: Add cvssv4 support

### DIFF
--- a/tests/fixtures/payloads.py
+++ b/tests/fixtures/payloads.py
@@ -45,25 +45,77 @@ cve1 = {
             "exploitabilityScore": 0.8,
             "impactScore": 3.6,
         },
-        "baseMetricV3": {
-            "cvssV3": {
-                "attackComplexity": "LOW",
-                "attackVector": "Local",
-                "availabilityImpact": "NONE",
-                "baseScore": 4.4,
-                "baseSeverity": "MEDIUM",
-                "confidentialityImpact": "HIGH",
-                "integrityImpact": "NONE",
-                "privilegesRequired": "HIGH",
-                "scope": "UNCHANGED",
-                "userInteraction": "NONE",
-                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N",
-                "version": "3.1",
-            },
-            "exploitabilityScore": 0.8,
-            "impactScore": 3.6,
-        }
-
+        "baseMetricV4": {
+            "cvssV4": {
+                "version": "4.0",
+                "vectorString": (
+                    "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/"
+                    + "VC:N/VI:N/VA:N/SC:N/SI:N/SA:N"
+                ),
+                "baseMetrics": {
+                    "exploitabilityMetrics": {
+                        "attackVector": "NETWORK",
+                        "attackComplexity": "LOW",
+                        "attackRequirements": "NONE",
+                        "privilegesRequired": "NONE",
+                        "userInteraction": "NONE",
+                    },
+                    "vulnerableSystemImpactMetrics": {
+                        "confidentialityImpact": "NONE",
+                        "integrityImpact": "NONE",
+                        "availabilityImpact": "NONE",
+                    },
+                    "subsequentSystemImpactMetrics": {
+                        "confidentialityImpact": "NONE",
+                        "integrityImpact": "NONE",
+                        "availabilityImpact": "NONE",
+                    },
+                },
+                "supplementalMetrics": {
+                    "safety": "NOT DEFINED",
+                    "automatable": "NOT DEFINED",
+                    "recovery": "NOT DEFINED",
+                    "valueDensity": "NOT DEFINED",
+                    "vulnerabilityResponseEffort": "NOT DEFINED",
+                    "providerUrgency": "NOT DEFINED",
+                },
+                "environmentalMetrics": {
+                    "modifiedBaseMetrics": {
+                        "exploitabilityMetrics": {
+                            "attackVector": "NOT DEFINED",
+                            "attackComplexity": "NOT DEFINED",
+                            "attackRequirements": "NOT DEFINED",
+                            "privilegesRequired": "NOT DEFINED",
+                            "userInteraction": "NOT DEFINED",
+                        },
+                        "vulnerableSystemImpactMetrics": {
+                            "confidentialityImpact": "NOT DEFINED",
+                            "integrityImpact": "NOT DEFINED",
+                            "availabilityImpact": "NOT DEFINED",
+                        },
+                        "subsequentSystemImpactMetrics": {
+                            "confidentialityImpact": "NOT DEFINED",
+                            "integrityImpact": "NOT DEFINED",
+                            "availabilityImpact": "NOT DEFINED",
+                        },
+                    },
+                    "securityRequirements": {
+                        "confidentialityRequirements": "NOT DEFINED",
+                        "integrityRequirements": "NOT DEFINED",
+                        "availabilityRequirements": "NOT DEFINED",
+                    },
+                },
+                "threatMetrics": {"exploitMaturity": "NOT DEFINED"},
+                "baseScore": 0.0,
+                "baseSeverity": "NONE",
+                "baseEnvironmentalScore": 0.0,
+                "baseEnvironmentalSeverity": "NONE",
+                "baseThreatScore": 0.0,
+                "baseThreatSeverity": "NONE",
+                "baseThreatEnvironmentalScore": 0.0,
+                "baseThreatEnvironmentalSeverity": "NONE",
+            }
+        },
     },
     "priority": "critical",
     "published": "2020-08-01 12:42:54",

--- a/tests/fixtures/payloads.py
+++ b/tests/fixtures/payloads.py
@@ -44,7 +44,26 @@ cve1 = {
             },
             "exploitabilityScore": 0.8,
             "impactScore": 3.6,
+        },
+        "baseMetricV3": {
+            "cvssV3": {
+                "attackComplexity": "LOW",
+                "attackVector": "Local",
+                "availabilityImpact": "NONE",
+                "baseScore": 4.4,
+                "baseSeverity": "MEDIUM",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "privilegesRequired": "HIGH",
+                "scope": "UNCHANGED",
+                "userInteraction": "NONE",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N",
+                "version": "3.1",
+            },
+            "exploitabilityScore": 0.8,
+            "impactScore": 3.6,
         }
+
     },
     "priority": "critical",
     "published": "2020-08-01 12:42:54",

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -508,31 +508,132 @@ class CveBaseMetric(Schema):
         render_module = orjson
 
 
-class CvssV4(Schema):
-    version = String(allow_none=True)
-    vectorString = String(allow_none=True)
+class CvssV4ExploitabilityMetrics(Schema):
     attackVector = String(allow_none=True)
     attackComplexity = String(allow_none=True)
     attackRequirements = String(allow_none=True)
     privilegesRequired = String(allow_none=True)
     userInteraction = String(allow_none=True)
-    vulnerableSystemConfidentialityImpact = String(allow_none=True)
-    vulnerableSystemIntegrityImpact = String(allow_none=True)
-    vulnerableSystemAvailabilityImpact = String(allow_none=True)
-    subsequentSystemConfidentialityImpact = String(allow_none=True)
-    subsequentSystemIntegrityImpact = String(allow_none=True)
-    subsequentSystemAvailabilityImpact = String(allow_none=True)
+
+    class Meta:
+        render_module = orjson
+
+
+class CvssV4VulnerableSystemImpactMetrics(Schema):
+    confidentialityImpact = String(allow_none=True)
+    integrityImpact = String(allow_none=True)
+    availabilityImpact = String(allow_none=True)
+
+    class Meta:
+        render_module = orjson
+
+
+class CvssV4SubsequentSystemImpactMetrics(Schema):
+    confidentialityImpact = String(allow_none=True)
+    integrityImpact = String(allow_none=True)
+    availabilityImpact = String(allow_none=True)
+
+    class Meta:
+        render_module = orjson
+
+
+class CvssV4BaseMetrics(Schema):
+    exploitabilityMetrics = Nested(
+        CvssV4ExploitabilityMetrics, allow_none=True
+    )
+    vulnerableSystemImpactMetrics = Nested(
+        CvssV4VulnerableSystemImpactMetrics, allow_none=True
+    )
+    subsequentSystemImpactMetrics = Nested(
+        CvssV4SubsequentSystemImpactMetrics, allow_none=True
+    )
+
+    class Meta:
+        render_module = orjson
+
+
+class CvssV4SupplementalMetrics(Schema):
+    safety = String(allow_none=True)
+    automatable = String(allow_none=True)
+    recovery = String(allow_none=True)
+    valueDensity = String(allow_none=True)
+    vulnerabilityResponseEffort = String(allow_none=True)
+    providerUrgency = String(allow_none=True)
+
+    class Meta:
+        render_module = orjson
+
+
+class CvssV4ModifiedBaseMetrics(Schema):
+    exploitabilityMetrics = Nested(
+        CvssV4ExploitabilityMetrics, allow_none=True
+    )
+    vulnerableSystemImpactMetrics = Nested(
+        CvssV4VulnerableSystemImpactMetrics, allow_none=True
+    )
+    subsequentSystemImpactMetrics = Nested(
+        CvssV4SubsequentSystemImpactMetrics, allow_none=True
+    )
+
+    class Meta:
+        render_module = orjson
+
+
+class CvssV4SecurityRequirements(Schema):
+    confidentialityRequirements = String(allow_none=True)
+    integrityRequirements = String(allow_none=True)
+    availabilityRequirements = String(allow_none=True)
+
+    class Meta:
+        render_module = orjson
+
+
+class CvssV4EnvironmentalMetrics(Schema):
+    modifiedBaseMetrics = Nested(CvssV4ModifiedBaseMetrics, allow_none=True)
+    securityRequirements = Nested(CvssV4SecurityRequirements, allow_none=True)
+
+    class Meta:
+        render_module = orjson
+
+
+class CvssV4ThreatMetrics(Schema):
+    exploitMaturity = String(allow_none=True)
+
+    class Meta:
+        render_module = orjson
+
+
+class CvssV4(Schema):
+    version = String(allow_none=True)
+    vectorString = String(allow_none=True)
+
+    baseMetrics = Nested(CvssV4BaseMetrics, allow_none=True)
+    supplementalMetrics = Nested(CvssV4SupplementalMetrics, allow_none=True)
+    environmentalMetrics = Nested(CvssV4EnvironmentalMetrics, allow_none=True)
+    threatMetrics = Nested(CvssV4ThreatMetrics, allow_none=True)
+
     baseScore = Float(allow_none=True)
     baseSeverity = String(allow_none=True)
 
+    baseEnvironmentalScore = Float(allow_none=True)
+    baseEnvironmentalSeverity = String(allow_none=True)
+
+    baseThreatScore = Float(allow_none=True)
+    baseThreatSeverity = String(allow_none=True)
+
+    baseThreatEnvironmentalScore = Float(allow_none=True)
+    baseThreatEnvironmentalSeverity = String(allow_none=True)
+
     class Meta:
         render_module = orjson
+
 
 class CveBaseMetricV4(Schema):
-    cvssV4 = Nested(CvssV4)
+    cvssV4 = Nested(CvssV4, allow_none=True)
 
     class Meta:
         render_module = orjson
+
 
 class CveImpact(Schema):
     baseMetricV3 = Nested(CveBaseMetric)

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -508,8 +508,35 @@ class CveBaseMetric(Schema):
         render_module = orjson
 
 
+class CvssV4(Schema):
+    version = String(allow_none=True)
+    vectorString = String(allow_none=True)
+    attackVector = String(allow_none=True)
+    attackComplexity = String(allow_none=True)
+    attackRequirements = String(allow_none=True)
+    privilegesRequired = String(allow_none=True)
+    userInteraction = String(allow_none=True)
+    vulnerableSystemConfidentialityImpact = String(allow_none=True)
+    vulnerableSystemIntegrityImpact = String(allow_none=True)
+    vulnerableSystemAvailabilityImpact = String(allow_none=True)
+    subsequentSystemConfidentialityImpact = String(allow_none=True)
+    subsequentSystemIntegrityImpact = String(allow_none=True)
+    subsequentSystemAvailabilityImpact = String(allow_none=True)
+    baseScore = Float(allow_none=True)
+    baseSeverity = String(allow_none=True)
+
+    class Meta:
+        render_module = orjson
+
+class CveBaseMetricV4(Schema):
+    cvssV4 = Nested(CvssV4)
+
+    class Meta:
+        render_module = orjson
+
 class CveImpact(Schema):
     baseMetricV3 = Nested(CveBaseMetric)
+    baseMetricV4 = Nested(CveBaseMetricV4)
 
     class Meta:
         render_module = orjson


### PR DESCRIPTION
## Done

- Added CVSS4 support, target fields come from the [cvss4 spec doc](https://www.first.org/cvss/v4-0/specification-document) and confirmed by security team via MM, example pastebin [here](https://pastebin.canonical.com/p/KzYfTwhKZ5/)

## QA

- See that tests pass (there's a test already for the upsert function and CVSS4 metrics have been added to the payload to confirm that it works as expected)
- Alternatively, you can also check functionality directly by:
  - Populate the db with a dump if you have not already done so 
  - Update the `scripts/payloads/cves.json` file to include [the following](https://pastebin.canonical.com/p/MSBjrhCwcs/) under the `impact field`
  - Run `dotrun exec scripts/create-cves.py --auth oauth --host <your_host_url> scripts/payloads/cves.json` (you may not need to pass the host, I typically do as I'm on WSL and my set up is a bit different)
  - Complete the auth process and see that you are returned 200 for your request
  - Visit http://0.0.0.0:8030/security/cves.json?q=CVE-2019-20504 (the id of the cve in the payload) and confirm that the cvss4 fields you passed are present


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-24753
