### PR TITLE
Fix: Added pg_trgm extension to migration file

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -79,7 +79,7 @@ jobs:
     needs: [pack-charm, publish-image]
     environment:
       name: staging
-      url: https://staging.ubuntu.com/security/
+      url: https://staging.ubuntu.com/security/api/docs
     steps:
       - name: Install Dependencies
         run: |
@@ -131,7 +131,7 @@ jobs:
     needs: [pack-charm, publish-image]
     environment:
       name: production
-      url: https://ubuntu.com/security/
+      url: https://ubuntu.com/security/api/docs
     steps:
       - name: Install Dependencies
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -79,7 +79,7 @@ jobs:
     needs: [pack-charm, publish-image]
     environment:
       name: staging
-      url: https://staging.ubuntu.com/security/api
+      url: https://staging.ubuntu.com/security/
     steps:
       - name: Install Dependencies
         run: |
@@ -131,7 +131,7 @@ jobs:
     needs: [pack-charm, publish-image]
     environment:
       name: production
-      url: https://ubuntu.com/security/api
+      url: https://ubuntu.com/security/
     steps:
       - name: Install Dependencies
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -93,7 +93,7 @@ jobs:
       - name: Python dependencies
         run: |
           python3 -m pip install --upgrade pip
-          sudo pip3 install flake8 black
+          sudo pip3 install flake8 black==25.1.0
 
       - name: Lint python
         run: yarn lint-python

--- a/migrations/versions/5ad36b3ca4ba_add_indexes_for_cve_search.py
+++ b/migrations/versions/5ad36b3ca4ba_add_indexes_for_cve_search.py
@@ -17,7 +17,10 @@ depends_on = None
 
 
 def upgrade():
-    # Create GIN indexes with pg_trgm ops on cve table (assumes extension already exists)
+    # Ensure the extension exists BEFORE creating indexes
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+
+    # Create GIN indexes with pg_trgm ops
     op.execute("CREATE INDEX idx_cve_description_trgm ON cve USING gin (description gin_trgm_ops)")
     op.execute("CREATE INDEX idx_cve_ubuntu_description_trgm ON cve USING gin (ubuntu_description gin_trgm_ops)")
     op.execute("CREATE INDEX idx_cve_codename_trgm ON cve USING gin (codename gin_trgm_ops)")


### PR DESCRIPTION
## Done

- Added pg_trgm extension to migration file

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Check if the site runs well locally.
- This change successfully unblocked migration issues on PS-6
- Check deployment was successful (https://github.com/canonical/ubuntu-com-security-api/actions/runs/21579901375/job/62175649317?pr=251) and see you can access the api on internal endpoint(please ask)


