### PR TITLE
fix: Eager load CVE notices on single notice endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 canonicalwebteam.flask-base @ git+https://github.com/canonical/canonicalwebteam.flask-base@add-compression-override-option
+setuptools<81
 alchemy-mock==0.4.3
 apispec==4.7.1
 cryptography==46.0.3

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -589,7 +589,10 @@ def get_notice_v2(notice_id, **kwargs):
 
     notice: Notice = (
         notice_query.filter(Notice.id == notice_id.upper())
-        .options(selectinload(Notice.cves), selectinload(Notice.releases))
+        .options(
+            selectinload(Notice.cves).selectinload(CVE.notices),
+            selectinload(Notice.releases),
+        )
         .one_or_none()
     )
 


### PR DESCRIPTION
## Done

- Eager loaded CVE notices to avoid N+1 queries causing timeouts (essentially mirroring what we did for the notices list endpoint)

## QA

- No real qa here, just see that tests pass

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-34348
