### PR TITLE
feat: added ordering for packages

### DIFF
--- a/migrations/versions/b3f1a2c4d5e6_add_status_package_order.py
+++ b/migrations/versions/b3f1a2c4d5e6_add_status_package_order.py
@@ -1,0 +1,30 @@
+"""add package_order column to status
+
+Stores the position of each package within a CVE as supplied by the source
+JSON, so that the API can return packages in the original "order of interest"
+(e.g. linux before linux-hwe) instead of an arbitrary database order.
+
+Revision ID: b3f1a2c4d5e6
+Revises: 0e647dd16ef6
+Create Date: 2026-06-09 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "b3f1a2c4d5e6"
+down_revision = "0e647dd16ef6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "status", sa.Column("package_order", sa.Integer(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("status", "package_order")

--- a/tests/fixtures/payloads.py
+++ b/tests/fixtures/payloads.py
@@ -407,3 +407,39 @@ release3 = {
     "esm_expires": "2022-01-31",
     "support_expires": "2022-01-31",
 }
+
+
+def _kernel_package(name):
+    return {
+        "name": name,
+        "source": f"https://ubuntu.com/security/cve?package={name}",
+        "ubuntu": (
+            "https://packages.ubuntu.com/search?suite=all&section=all&arch"
+            f"=any&searchon=sourcenames&keywords={name}"
+        ),
+        "debian": f"https://tracker.debian.org/pkg/{name}",
+        "statuses": [
+            {
+                "description": "",
+                "release_codename": "testrelease",
+                "status": "released",
+                "pocket": "security",
+            }
+        ],
+    }
+
+
+# Kernel packages listed in their "order of interest" rather than
+# alphabetically (alphabetical would be linux, linux-aws, linux-hwe).
+cve_package_order = {
+    "id": "CVE-9999-1000",
+    "codename": "testcodename_order",
+    "priority": "critical",
+    "published": "2020-08-01 12:42:54",
+    "status": "active",
+    "packages": [
+        _kernel_package("linux"),
+        _kernel_package("linux-hwe"),
+        _kernel_package("linux-aws"),
+    ],
+}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -45,6 +45,28 @@ class TestRoutes(BaseTestCase):
         )
         assert response.json["notices_ids"] == self.models["cve"].notices_ids
 
+    def test_cve_packages_preserve_source_order(self):
+        """
+        Packages should be returned in the same order they were supplied in
+        the source JSON (the "order of interest"), not alphabetically.
+        """
+        upsert_response = self.client.put(
+            "/security/updates/cves.json",
+            json=[payloads.cve_package_order],
+        )
+        assert upsert_response.status_code == 200
+
+        response = self.client.get(
+            f"/security/cves/{payloads.cve_package_order['id']}.json"
+        )
+        assert response.status_code == 200
+
+        returned_names = [pkg["name"] for pkg in response.json["packages"]]
+        expected_names = [
+            pkg["name"] for pkg in payloads.cve_package_order["packages"]
+        ]
+        assert returned_names == expected_names
+
     def test_cves_query_no_500(self):
         response = self.client.get("/security/cves.json?q=firefox")
 

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     Enum,
     Float,
     ForeignKey,
+    Integer,
     JSON,
     Numeric,
     String,
@@ -93,7 +94,15 @@ class CVE(db.Model):
     @hybrid_property
     def package_statuses(self):
         package_statuses = {}
-        for status in self.statuses:
+        ordered_statuses = sorted(
+            self.statuses,
+            key=lambda status: (
+                status.package_order is None,
+                status.package_order or 0,
+                status.package_name,
+            ),
+        )
+        for status in ordered_statuses:
             if not package_statuses.get(status.package_name):
                 package_statuses[status.package_name] = {
                     "name": status.package_name,
@@ -266,6 +275,7 @@ class Status(db.Model):
     description = Column(String)
     component = Column(COMPONENT_OPTIONS)
     pocket = Column(POCKET_OPTIONS)
+    package_order = Column(Integer)
 
     cve = relationship("CVE", back_populates="statuses")
     package = relationship("Package", back_populates="statuses")

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1121,7 +1121,7 @@ def _update_statuses(cve, data, packages):
 
     statuses_to_delete = {key: None for key in existing_status_keys}
 
-    for package_data in data.get("packages", []):
+    for package_order, package_data in enumerate(data.get("packages", [])):
         name = package_data["name"]
 
         if packages.get(name) is None:
@@ -1161,6 +1161,10 @@ def _update_statuses(cve, data, packages):
             if status.pocket != status_data.get("pocket"):
                 update_status = True
                 status.pocket = status_data.get("pocket")
+
+            if status.package_order != package_order:
+                update_status = True
+                status.package_order = package_order
 
             if update_status:
                 statuses[name][codename] = status


### PR DESCRIPTION
## Done
- Fixed CVE package lists being returned in arbitrary order on security.ubuntu.com
- Packages now preserve the source JSON's prder (e.g. `linux` before `linux-hwe`) instead of an arbitrary/alphabetical DB order

## QA
- Clone the branch and run it locally using `dotrun`
- Ensure that tests pass properly

## Issue / Card
https://warthogs.atlassian.net/browse/WD-36988
