### PR TITLE
fix: add storageClassName to updates StatefulSet volumeClaimTemplates

### DIFF
--- a/konf/raw-site-updates.yaml
+++ b/konf/raw-site-updates.yaml
@@ -106,6 +106,7 @@ spec:
       name: www
     spec:
       accessModes: ["ReadWriteOnce"]
+      storageClassName: cdk-cinder
       resources:
         requests:
           storage: 1Gi


### PR DESCRIPTION
## Done

- Added storageClassName: cdk-cinder to the www volumeClaimTemplate

## Context
Prod deployments are currently failing because the updates service StatefulSet's `volumeClaimTemplates` has no `storageClassName` set, which causes any new PVC to get stuck as pending with no storage class to bind against. This in turn causes the Jenkins deploy script to hang on the `kubectl rollout status statefulset` check for updates. This PR defines the storage class explicitly so new PVCs can always bind regardless of cluster defaults.

_Note: `kubernetes-53` was also taken out of rotation during this fix as it has a broken storage driver. `updates-1` was initially scheduled there and couldn't attach its volume. This is a separate node-level issue that should be  investigated independently._

## QA

No QA needed, this has already been applied and is working, updates pods are once again passing readiness checks. This PR just aligns what was applied manually so that it is not overwritten by any future merges


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-37229