### PR TITLE
fix: remove sentry_dsn config to disable sentry

### DIFF
--- a/konf/raw-site-flat-notices.yaml
+++ b/konf/raw-site-flat-notices.yaml
@@ -70,9 +70,6 @@ spec:
                   key: database_url
                   name: usn-db-url
 
-            - name: SENTRY_DSN
-              value: "https://1e974d641a14437e9573e8fe9958a252@sentry.is.canonical.com//48"
-
           readinessProbe:
             httpGet:
               path: /_status/check

--- a/konf/raw-site-notices.yaml
+++ b/konf/raw-site-notices.yaml
@@ -73,9 +73,6 @@ spec:
                   key: database-url
                   name: usndbreplicatwo
 
-            - name: SENTRY_DSN
-              value: "https://1e974d641a14437e9573e8fe9958a252@sentry.is.canonical.com//48"
-
           readinessProbe:
             httpGet:
               path: /_status/check

--- a/konf/raw-site-updates.yaml
+++ b/konf/raw-site-updates.yaml
@@ -83,9 +83,6 @@ spec:
             - name: REQUEST_TOKENS_FILE
               value: "/etc/ubuntu-com-security-api/request-tokens"
 
-            - name: SENTRY_DSN
-              value: "https://1e974d641a14437e9573e8fe9958a252@sentry.is.canonical.com//48"
-
           readinessProbe:
             httpGet:
               path: /_status/check

--- a/konf/raw-site.yaml
+++ b/konf/raw-site.yaml
@@ -73,9 +73,6 @@ spec:
                   key: database-url
                   name: usndbreplica
 
-            - name: SENTRY_DSN
-              value: "https://1e974d641a14437e9573e8fe9958a252@sentry.is.canonical.com//48"
-
           readinessProbe:
             httpGet:
               path: /_status/check


### PR DESCRIPTION
## Problem statement

- security api is dependent on an old version of sentry that has been decommissioned  

## Done

- remove sentry_dsn from config, the app handles missing config gracefully
- addresses the issue reported [here](https://chat.canonical.com/canonical/pl/cej9zisenpbb8ggs5tjuz6gdzc)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Run through the following [QA steps](https://canonical-web-and-design.github
.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been reso
lved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
