### PR TITLE
fix: treat NULL package_order as 0 to avoid redundant status updates

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1162,7 +1162,7 @@ def _update_statuses(cve, data, packages):
                 update_status = True
                 status.pocket = status_data.get("pocket")
 
-            if (status.package_order or 0) != package_order:
+            if update_status or (status.package_order or 0) != package_order:
                 update_status = True
                 status.package_order = package_order
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1162,7 +1162,7 @@ def _update_statuses(cve, data, packages):
                 update_status = True
                 status.pocket = status_data.get("pocket")
 
-            if status.package_order != package_order:
+            if (status.package_order or 0) != package_order:
                 update_status = True
                 status.package_order = package_order
 


### PR DESCRIPTION
## Done

- Fixed the package_order comparison in _update_statuses to treat NULL as 0 for existing rows

## Context

[This pr](https://github.com/canonical/ubuntu-com-security-api/pull/271) added a `package_order` column to the status table to preserve the order packages are listed under a CVE, but the migration added the column as nullable with no backfill, leaving all existing rows with `package_order = NULL`. On every upsert, the code compares the stored order against the incoming position (None != 0 always evaluates to true in Python), so every existing status row was flagged dirty and updated on every import, even when nothing had changed. This caused the upsert endpoint to time out after 300s under the gunicorn worker limit which is in turn leading to 500s.

Note that this is just a patch for the existing outage, the linked pr still carries write concerns as it stores  `package_order` compares it on every individual status row on every import. The follow up work will be tracked in a separate pr.

## QA

- No QA as there isn't really an easy way to recreate this locally  


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
