### PR TITLE
fix: skip package_order UPDATE for existing NULL rows

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1162,7 +1162,11 @@ def _update_statuses(cve, data, packages):
                 update_status = True
                 status.pocket = status_data.get("pocket")
 
-            if update_status or (status.package_order or 0) != package_order:
+            order_changed = (
+                status.package_order is not None
+                and status.package_order != package_order
+            )
+            if update_status or order_changed:
                 update_status = True
                 status.package_order = package_order
 


### PR DESCRIPTION
## Done

- Skip package_order UPDATE for existing NULL rows to prevent upsert timeout

## Context
This essentially brings the package ordering issue back to where it was before [this pr](https://github.com/canonical/ubuntu-com-security-api/pull/271) attempted to solve it, but it is preferable for now if it means avoiding the entire upsert service being blocked. [Previous patch](https://github.com/canonical/ubuntu-com-security-api/pull/276) failed to check for every position and was not thorough enough.

## QA

- No QA as there isn't an easy way to do so locally


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
