### PR TITLE
config: increase periodSeconds and timeoutSeconds for readinessProbe

### DIFF
--- a/konf/raw-site-notices.yaml
+++ b/konf/raw-site-notices.yaml
@@ -77,8 +77,9 @@ spec:
             httpGet:
               path: /_status/check
               port: 80
-            periodSeconds: 5
-            timeoutSeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
 
           resources:
             requests:

--- a/konf/raw-site.yaml
+++ b/konf/raw-site.yaml
@@ -77,8 +77,9 @@ spec:
             httpGet:
               path: /_status/check
               port: 80
-            periodSeconds: 5
-            timeoutSeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
 
           resources:
             requests:


### PR DESCRIPTION
## Done

- increase periodSeconds and timeoutSeconds to increase time marked for unhealthy pods
- Time marked ~= `periodSeconds` x `failureThreshold`
- Previously 15s > Now 30s
- `failureThreshold` is 3 by default

## QA

- Once merged, check pod logs that periodSeconds for status check is done in every 10s instead of 5s


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
