### PR TITLE
feat: add sentry sdk

### DIFF
--- a/.env
+++ b/.env
@@ -9,3 +9,4 @@ REPLICA_TWO_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
 TEST_DATABASE_URL=postgresql://postgres@localhost:5432/testdb
 DOTRUN_DOCKER_COMPOSE_ACTIONS=start:serve:test:test-python
 OAUTH_TOKEN_SALT=BxyxJx9wr/5GmVeI+k2mFkJKjeHt5mP590tjK/CCmDA=
+FLASK_ENV=demo

--- a/.env
+++ b/.env
@@ -9,4 +9,4 @@ REPLICA_TWO_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
 TEST_DATABASE_URL=postgresql://postgres@localhost:5432/testdb
 DOTRUN_DOCKER_COMPOSE_ACTIONS=start:serve:test:test-python
 OAUTH_TOKEN_SALT=BxyxJx9wr/5GmVeI+k2mFkJKjeHt5mP590tjK/CCmDA=
-FLASK_ENV=demo
+FLASK_ENV=development

--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -43,3 +43,7 @@ config:
     oauth-token-salt:
       type: secret
       description: "Salt used to encode and decode OAuth tokens"
+    sentry-dsn:
+      type: string
+      description: "Sentry DSN for error tracking"
+      default: "https://88233b54cb8e9f8d8df4ace2349e0b8b@o4510662863749120.ingest.de.sentry.io/4511652407345232"

--- a/konf/raw-site-flat-notices.yaml
+++ b/konf/raw-site-flat-notices.yaml
@@ -71,7 +71,6 @@ spec:
                   name: usn-db-url
 
             - name: SENTRY_DSN
-              description: "Sentry DSN for error tracking"
               value: "https://88233b54cb8e9f8d8df4ace2349e0b8b@o4510662863749120.ingest.de.sentry.io/4511652407345232"
 
           readinessProbe:

--- a/konf/raw-site-flat-notices.yaml
+++ b/konf/raw-site-flat-notices.yaml
@@ -70,6 +70,10 @@ spec:
                   key: database_url
                   name: usn-db-url
 
+            - name: SENTRY_DSN
+              description: "Sentry DSN for error tracking"
+              value: "https://88233b54cb8e9f8d8df4ace2349e0b8b@o4510662863749120.ingest.de.sentry.io/4511652407345232"
+
           readinessProbe:
             httpGet:
               path: /_status/check

--- a/konf/raw-site-notices.yaml
+++ b/konf/raw-site-notices.yaml
@@ -74,7 +74,6 @@ spec:
                   name: usndbreplicatwo
 
             - name: SENTRY_DSN
-              description: "Sentry DSN for error tracking"
               value: "https://88233b54cb8e9f8d8df4ace2349e0b8b@o4510662863749120.ingest.de.sentry.io/4511652407345232"
 
           readinessProbe:

--- a/konf/raw-site-notices.yaml
+++ b/konf/raw-site-notices.yaml
@@ -73,6 +73,10 @@ spec:
                   key: database-url
                   name: usndbreplicatwo
 
+            - name: SENTRY_DSN
+              description: "Sentry DSN for error tracking"
+              value: "https://88233b54cb8e9f8d8df4ace2349e0b8b@o4510662863749120.ingest.de.sentry.io/4511652407345232"
+
           readinessProbe:
             httpGet:
               path: /_status/check

--- a/konf/raw-site-updates.yaml
+++ b/konf/raw-site-updates.yaml
@@ -83,6 +83,10 @@ spec:
             - name: REQUEST_TOKENS_FILE
               value: "/etc/ubuntu-com-security-api/request-tokens"
 
+            - name: SENTRY_DSN
+              description: "Sentry DSN for error tracking"
+              value: "https://88233b54cb8e9f8d8df4ace2349e0b8b@o4510662863749120.ingest.de.sentry.io/4511652407345232"
+
           readinessProbe:
             httpGet:
               path: /_status/check

--- a/konf/raw-site-updates.yaml
+++ b/konf/raw-site-updates.yaml
@@ -84,7 +84,6 @@ spec:
               value: "/etc/ubuntu-com-security-api/request-tokens"
 
             - name: SENTRY_DSN
-              description: "Sentry DSN for error tracking"
               value: "https://88233b54cb8e9f8d8df4ace2349e0b8b@o4510662863749120.ingest.de.sentry.io/4511652407345232"
 
           readinessProbe:

--- a/konf/raw-site.yaml
+++ b/konf/raw-site.yaml
@@ -50,7 +50,6 @@ spec:
               value: 10.0.0.0/8
 
             - name: SENTRY_DSN
-              description: "Sentry DSN for error tracking"
               value: "https://88233b54cb8e9f8d8df4ace2349e0b8b@o4510662863749120.ingest.de.sentry.io/4511652407345232"
 
             - name: GUNICORN_TIMEOUT

--- a/konf/raw-site.yaml
+++ b/konf/raw-site.yaml
@@ -49,6 +49,10 @@ spec:
             - name: TALISKER_NETWORKS
               value: 10.0.0.0/8
 
+            - name: SENTRY_DSN
+              description: "Sentry DSN for error tracking"
+              value: "https://88233b54cb8e9f8d8df4ace2349e0b8b@o4510662863749120.ingest.de.sentry.io/4511652407345232"
+
             - name: GUNICORN_TIMEOUT
               value: "30"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ Flask-Migrate==3.1.0
 SQLAlchemy-Utils==0.41.1
 orjson==3.11.0
 gunicorn==21.2.0
+sentry-sdk[flask]==2.49.0

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -122,7 +122,7 @@ environment = get_flask_env("FLASK_ENV", "production")
 if sentry_dsn:
     sentry_sdk.init(
         dsn=sentry_dsn,
-        send_default_pii=True,
+        send_default_pii=False,
         environment=environment,
         integrations=[FlaskIntegration()],
     )
@@ -311,7 +311,7 @@ def handle_error(error):
     )
 
 
-if environment != "production":
+if sentry_dsn and environment != "production":
 
     @app.route("/sentry-debug")
     def trigger_error():

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -119,7 +119,7 @@ app.config.update(
 sentry_dsn = get_flask_env("SENTRY_DSN")
 environment = get_flask_env("FLASK_ENV", "production")
 
-if sentry_dsn:
+if sentry_dsn and environment == "production":
     sentry_sdk.init(
         dsn=sentry_dsn,
         send_default_pii=False,
@@ -309,11 +309,3 @@ def handle_error(error):
         jsonify({"message": "Invalid payload", "errors": str(messages)}),
         422,
     )
-
-
-if sentry_dsn and environment != "production":
-
-    @app.route("/sentry-debug")
-    def trigger_error():
-        """Endpoint to trigger a Sentry error for testing purposes."""
-        1 / 0

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -4,6 +4,9 @@ from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
 from canonicalwebteam.flask_base.app import FlaskBase
 from flask import jsonify, make_response
+from canonicalwebteam.flask_base.env import get_flask_env
+from sentry_sdk.integrations.flask import FlaskIntegration
+import sentry_sdk
 
 from webapp.api_spec import WebappFlaskApiSpec
 from webapp.commands import register_commands
@@ -112,6 +115,17 @@ app.config.update(
         "SQLALCHEMY_TRACK_MODIFICATIONS": False,
     },
 )
+
+sentry_dsn = get_flask_env("SENTRY_DSN")
+environment = get_flask_env("FLASK_ENV", "production")
+
+if sentry_dsn:
+    sentry_sdk.init(
+        dsn=sentry_dsn,
+        send_default_pii=True,
+        environment=environment,
+        integrations=[FlaskIntegration()],
+    )
 
 init_db(app)
 
@@ -295,3 +309,11 @@ def handle_error(error):
         jsonify({"message": "Invalid payload", "errors": str(messages)}),
         422,
     )
+
+
+if environment != "production":
+
+    @app.route("/sentry-debug")
+    def trigger_error():
+        """Endpoint to trigger a Sentry error for testing purposes."""
+        1 / 0


### PR DESCRIPTION
## Done

- Created `ubuntu-com-security-api` project on [Sentry](https://canonical-ax.sentry.io/settings/projects/ubuntu-com-security-api/teams/)
- Added `FLASK_ENV` and `/sentry-debug` for debugging purposes

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/sentry-debug
- See that an error is raised in Sentry under `demo` environment


## Issue / Card

Fixes [WD-37232](https://warthogs.atlassian.net/browse/WD-37232)

## Screenshots

[if relevant, include a screenshot]


[WD-37232]: https://warthogs.atlassian.net/browse/WD-37232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ