### PR TITLE
Fix gunicorn worker timeouts on notice and CVE endpoints

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -684,9 +684,7 @@ def get_notices_v2(**kwargs):
         ),
         selectinload(Notice.cves).options(
             load_only(CVE.id),
-            selectinload(CVE.notices).load_only(
-                Notice.id, Notice.is_hidden
-            ),
+            selectinload(CVE.notices).load_only(Notice.id, Notice.is_hidden),
         ),
         selectinload(Notice.releases),
     ).order_by(sort_order_by(Notice.published), sort_order_by(Notice.id))

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -591,7 +591,12 @@ def get_notice_v2(notice_id, **kwargs):
     notice: Notice = (
         notice_query.filter(Notice.id == notice_id.upper())
         .options(
-            selectinload(Notice.cves).selectinload(CVE.notices),
+            selectinload(Notice.cves).options(
+                load_only(CVE.id),
+                selectinload(CVE.notices).load_only(
+                    Notice.id, Notice.is_hidden
+                ),
+            ),
             selectinload(Notice.releases),
         )
         .one_or_none()
@@ -670,7 +675,12 @@ def get_notices_v2(**kwargs):
             Notice.published,
             Notice.is_hidden,
         ),
-        selectinload(Notice.cves).selectinload(CVE.notices),
+        selectinload(Notice.cves).options(
+            load_only(CVE.id),
+            selectinload(CVE.notices).load_only(
+                Notice.id, Notice.is_hidden
+            ),
+        ),
         selectinload(Notice.releases),
     ).order_by(sort_order_by(Notice.published), sort_order_by(Notice.id))
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -598,6 +598,7 @@ def get_notice_v2(notice_id, **kwargs):
     notice: Notice = (
         notice_query.filter(Notice.id == notice_id.upper())
         .options(
+            undefer(Notice.release_packages),
             selectinload(Notice.cves).options(
                 load_only(CVE.id),
                 selectinload(CVE.notices).load_only(
@@ -670,18 +671,13 @@ def get_notices_v2(**kwargs):
     total_results = notices_query.count()
 
     # Optimize the query:
-    # - Only select necessary scalar fields
+    # - Eager load release_packages (deferred) so serialization does not
+    #   trigger a per-notice lazy load
     # - Eager load related CVEs (and their notices for related_notices)
     # - Eager load related releases
     # - Apply final sort order
     notices_query = notices_query.options(
-        load_only(
-            Notice.id,
-            Notice.title,
-            Notice.details,
-            Notice.published,
-            Notice.is_hidden,
-        ),
+        undefer(Notice.release_packages),
         selectinload(Notice.cves).options(
             load_only(CVE.id),
             selectinload(CVE.notices).load_only(Notice.id, Notice.is_hidden),

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -13,7 +13,13 @@ from flask import (
 from flask_apispec import marshal_with, use_kwargs
 from sqlalchemy import asc, case, desc, distinct, func, or_, exists, tuple_
 from sqlalchemy.exc import DataError, IntegrityError
-from sqlalchemy.orm import Query, aliased, load_only, selectinload
+from sqlalchemy.orm import (
+    Query,
+    aliased,
+    load_only,
+    selectinload,
+    undefer,
+)
 
 from webapp.auth import authorization_required, oauth_authorization_required
 from webapp.database import db
@@ -206,7 +212,8 @@ def get_cves(**kwargs):
     cves_query = cves_query.options(
         selectinload(CVE.statuses),
         selectinload(cve_notices_query).options(
-            selectinload(Notice.cves).options(load_only(CVE.id))
+            undefer(Notice.release_packages),
+            selectinload(Notice.cves).options(load_only(CVE.id)),
         ),
     )
 


### PR DESCRIPTION
## Done

- Trimmed the notices eager-load in get_notice_v2/get_notices_v2 with load_only because it was hydrating every column of every notice across all a notice's CVEs, timing out the worker.
- Added [undefer(Notice.release_packages)](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [get_cves](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) because the deferred column triggered a per-notice N+1 lazy-load during serialization, timing out the worker.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Run through the following [QA steps](https://canonical-web-and-design.github
.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been reso
lved]


## Issue / Card

Fixes errors reported on Sentry:

