### PR TITLE
Fix gunicorn worker timeouts on v2 notice and CVE endpoints

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1208,6 +1208,35 @@ class TestRoutes(BaseTestCase):
             in response.json["notices"][0]["cves"][0]["notices_ids"]
         )
 
+    def test_v2_notices_exclude_hidden_notice_ids(self):
+        # A CVE linked to both a visible and a hidden notice
+        shared_cve = make_cve("CVE-9999-1000")
+        visible_notice = make_notice("USN-9999-1000", cves=[shared_cve])
+        hidden_notice = make_notice(
+            "USN-9999-1001", is_hidden=True, cves=[shared_cve]
+        )
+        self.db.session.add_all([shared_cve, visible_notice, hidden_notice])
+        self.db.session.commit()
+
+        def notices_ids(path):
+            # Expire cached objects so each request re-reads from the DB,
+            # as independent requests would in production.
+            self.db.session.expire_all()
+            payload = self.client.get(path).get_json()
+            cves = payload.get("cves") or payload["notices"][0]["cves"]
+            return {nid for cve in cves for nid in cve["notices_ids"]}
+
+        base = "/security/notices/USN-9999-1000.json"
+        # get_notice_v2: hidden id excluded by default, shown when requested
+        assert "USN-9999-1000" in notices_ids(base)
+        assert "USN-9999-1001" not in notices_ids(base)
+        assert "USN-9999-1001" in notices_ids(base + "?show_hidden=true")
+
+        # get_notices_v2: same behaviour via the list endpoint
+        listing = "/security/notices.json?cves=CVE-9999-1000"
+        assert "USN-9999-1001" not in notices_ids(listing)
+        assert "USN-9999-1001" in notices_ids(listing + "&show_hidden=true")
+
     def test_page_notice(self):
         response = self.client.get("/security/page/notices.json")
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1218,24 +1218,37 @@ class TestRoutes(BaseTestCase):
         self.db.session.add_all([shared_cve, visible_notice, hidden_notice])
         self.db.session.commit()
 
-        def notices_ids(path):
+        def cve_notices_ids(cves):
+            return {nid for cve in cves for nid in cve["notices_ids"]}
+
+        def get_json(path):
             # Expire cached objects so each request re-reads from the DB,
             # as independent requests would in production.
             self.db.session.expire_all()
-            payload = self.client.get(path).get_json()
-            cves = payload.get("cves") or payload["notices"][0]["cves"]
-            return {nid for cve in cves for nid in cve["notices_ids"]}
+            return self.client.get(path).get_json()
 
-        base = "/security/notices/USN-9999-1000.json"
-        # get_notice_v2: hidden id excluded by default, shown when requested
-        assert "USN-9999-1000" in notices_ids(base)
-        assert "USN-9999-1001" not in notices_ids(base)
-        assert "USN-9999-1001" in notices_ids(base + "?show_hidden=true")
+        # get_notice_v2 detail response shape: {"cves": [...]}
+        detail = get_json("/security/notices/USN-9999-1000.json")
+        assert "USN-9999-1000" in cve_notices_ids(detail["cves"])
+        assert "USN-9999-1001" not in cve_notices_ids(detail["cves"])
 
-        # get_notices_v2: same behaviour via the list endpoint
-        listing = "/security/notices.json?cves=CVE-9999-1000"
-        assert "USN-9999-1001" not in notices_ids(listing)
-        assert "USN-9999-1001" in notices_ids(listing + "&show_hidden=true")
+        detail = get_json(
+            "/security/notices/USN-9999-1000.json?show_hidden=true"
+        )
+        assert "USN-9999-1001" in cve_notices_ids(detail["cves"])
+
+        # get_notices_v2 list response shape: {"notices": [{"cves": [...]}]}
+        listing = get_json("/security/notices.json?cves=CVE-9999-1000")
+        assert "USN-9999-1001" not in cve_notices_ids(
+            listing["notices"][0]["cves"]
+        )
+
+        listing = get_json(
+            "/security/notices.json?cves=CVE-9999-1000&show_hidden=true"
+        )
+        assert "USN-9999-1001" in cve_notices_ids(
+            listing["notices"][0]["cves"]
+        )
 
     def test_page_notice(self):
         response = self.client.get("/security/page/notices.json")

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -13,7 +13,7 @@ from flask import (
 from flask_apispec import marshal_with, use_kwargs
 from sqlalchemy import asc, case, desc, distinct, func, or_, exists, tuple_
 from sqlalchemy.exc import DataError, IntegrityError
-from sqlalchemy.orm import Query, aliased, load_only, selectinload
+from sqlalchemy.orm import Query, aliased, load_only, selectinload, undefer
 
 from webapp.auth import authorization_required, oauth_authorization_required
 from webapp.database import db
@@ -206,7 +206,18 @@ def get_cves(**kwargs):
     cves_query = cves_query.options(
         selectinload(CVE.statuses),
         selectinload(cve_notices_query).options(
-            selectinload(Notice.cves).options(load_only(CVE.id))
+            load_only(
+                Notice.id,
+                Notice.title,
+                Notice.published,
+                Notice.summary,
+                Notice.details,
+                Notice.instructions,
+                Notice.references,
+                Notice.is_hidden,
+                Notice.release_packages,
+            ),
+            selectinload(Notice.cves).options(load_only(CVE.id)),
         ),
     )
 
@@ -585,13 +596,28 @@ def get_notices(**kwargs):
 def get_notice_v2(notice_id, **kwargs):
     notice_query: Query = db.session.query(Notice)
 
-    if not kwargs.get("show_hidden", False):
+    show_hidden = kwargs.get("show_hidden", False)
+
+    if not show_hidden:
         notice_query = notice_query.filter_by(is_hidden=False)
+
+    # Exclude hidden notices from the CVE.notices load unless requested, so
+    # hidden notice ids don't leak via cves[*].notices_ids. v2 serialises
+    # related notices as ids only, so only id + is_hidden are needed here.
+    cve_notices = CVE.notices
+    if not show_hidden:
+        cve_notices = cve_notices.and_(Notice.is_hidden.is_(False))
 
     notice: Notice = (
         notice_query.filter(Notice.id == notice_id.upper())
         .options(
-            selectinload(Notice.cves).selectinload(CVE.notices),
+            undefer(Notice.release_packages),
+            selectinload(Notice.cves).options(
+                load_only(CVE.id),
+                selectinload(cve_notices).options(
+                    load_only(Notice.id, Notice.is_hidden)
+                ),
+            ),
             selectinload(Notice.releases),
         )
         .one_or_none()
@@ -657,20 +683,27 @@ def get_notices_v2(**kwargs):
     # Count total matching results before pagination
     total_results = notices_query.count()
 
+    # Exclude hidden notices from the CVE.notices load unless requested, so
+    # hidden notice ids don't leak via cves[*].notices_ids. v2 serialises
+    # related notices as ids only, so only id + is_hidden are needed here.
+    cve_notices = CVE.notices
+    if not show_hidden:
+        cve_notices = cve_notices.and_(Notice.is_hidden.is_(False))
+
     # Optimize the query:
-    # - Only select necessary scalar fields
+    # - Eager load release_packages (deferred) so serialization does not
+    #   trigger a per-notice lazy load
     # - Eager load related CVEs (and their notices for related_notices)
     # - Eager load related releases
     # - Apply final sort order
     notices_query = notices_query.options(
-        load_only(
-            Notice.id,
-            Notice.title,
-            Notice.details,
-            Notice.published,
-            Notice.is_hidden,
+        undefer(Notice.release_packages),
+        selectinload(Notice.cves).options(
+            load_only(CVE.id),
+            selectinload(cve_notices).options(
+                load_only(Notice.id, Notice.is_hidden)
+            ),
         ),
-        selectinload(Notice.cves).selectinload(CVE.notices),
         selectinload(Notice.releases),
     ).order_by(sort_order_by(Notice.published), sort_order_by(Notice.id))
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -601,12 +601,8 @@ def get_notice_v2(notice_id, **kwargs):
     if not show_hidden:
         notice_query = notice_query.filter_by(is_hidden=False)
 
-    # Exclude hidden notices from the CVE.notices load unless requested, so
-    # hidden notice ids don't leak via cves[*].notices_ids. v2 serialises
-    # related notices as ids only, so only id + is_hidden are needed here.
-    cve_notices = CVE.notices
-    if not show_hidden:
-        cve_notices = cve_notices.and_(Notice.is_hidden.is_(False))
+    # v2 serialises related notices as ids only, so load just id + is_hidden.
+    cve_notices = _visible_cve_notices(show_hidden)
 
     notice: Notice = (
         notice_query.filter(Notice.id == notice_id.upper())
@@ -683,12 +679,8 @@ def get_notices_v2(**kwargs):
     # Count total matching results before pagination
     total_results = notices_query.count()
 
-    # Exclude hidden notices from the CVE.notices load unless requested, so
-    # hidden notice ids don't leak via cves[*].notices_ids. v2 serialises
-    # related notices as ids only, so only id + is_hidden are needed here.
-    cve_notices = CVE.notices
-    if not show_hidden:
-        cve_notices = cve_notices.and_(Notice.is_hidden.is_(False))
+    # v2 serialises related notices as ids only, so load just id + is_hidden.
+    cve_notices = _visible_cve_notices(show_hidden)
 
     # Optimize the query:
     # - Eager load release_packages (deferred) so serialization does not
@@ -1096,6 +1088,17 @@ def test_authorization_required():
     """Test method for auth."""
     print("Authorization test function called.")
     return "This is a test function for authorization_required decorator.", 200
+
+
+def _visible_cve_notices(show_hidden):
+    """CVE.notices relationship, excluding hidden notices unless show_hidden.
+
+    Centralises the security-sensitive filtering so the v2 notice endpoints
+    can't leak hidden notice ids via serialised ``notices_ids``.
+    """
+    if show_hidden:
+        return CVE.notices
+    return CVE.notices.and_(Notice.is_hidden.is_(False))
 
 
 def _sort_by_priority(cves_query):


### PR DESCRIPTION
## Done

- Fixed 2 gunicorn worker timeout Sentry errors on the v2 notice and CVE endpoints, both caused by inefficient SQLAlchemy eager-loading during serialisation. Each endpoint now loads exactly what its schema serialises.


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Run through the following [QA steps](https://canonical-web-and-design.github
.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been reso
lved]


## Issue / Card

Fixes errors reported on Sentry:

