### PR TITLE
fix: scope nested related-notices eager load to id/is_hidden columns

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -591,9 +591,9 @@ def get_notice_v2(notice_id, **kwargs):
     notice: Notice = (
         notice_query.filter(Notice.id == notice_id.upper())
         .options(
-            selectinload(Notice.cves).selectinload(CVE.notices).options(
-                load_only(Notice.id, Notice.is_hidden)
-            ),
+            selectinload(Notice.cves)
+            .selectinload(CVE.notices)
+            .options(load_only(Notice.id, Notice.is_hidden)),
             selectinload(Notice.releases),
         )
         .one_or_none()
@@ -672,9 +672,9 @@ def get_notices_v2(**kwargs):
             Notice.published,
             Notice.is_hidden,
         ),
-        selectinload(Notice.cves).selectinload(CVE.notices).options(
-            load_only(Notice.id, Notice.is_hidden)
-        ),
+        selectinload(Notice.cves)
+        .selectinload(CVE.notices)
+        .options(load_only(Notice.id, Notice.is_hidden)),
         selectinload(Notice.releases),
     ).order_by(sort_order_by(Notice.published), sort_order_by(Notice.id))
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -591,7 +591,9 @@ def get_notice_v2(notice_id, **kwargs):
     notice: Notice = (
         notice_query.filter(Notice.id == notice_id.upper())
         .options(
-            selectinload(Notice.cves).selectinload(CVE.notices),
+            selectinload(Notice.cves).selectinload(CVE.notices).options(
+                load_only(Notice.id, Notice.is_hidden)
+            ),
             selectinload(Notice.releases),
         )
         .one_or_none()
@@ -670,7 +672,9 @@ def get_notices_v2(**kwargs):
             Notice.published,
             Notice.is_hidden,
         ),
-        selectinload(Notice.cves).selectinload(CVE.notices),
+        selectinload(Notice.cves).selectinload(CVE.notices).options(
+            load_only(Notice.id, Notice.is_hidden)
+        ),
         selectinload(Notice.releases),
     ).order_by(sort_order_by(Notice.published), sort_order_by(Notice.id))
 


### PR DESCRIPTION
## Done

- Scoped the nested CVE.notices eager load to only id/is_hidden, instead of the full row

## QA

- Check out this feature branch
- Run the site locally using `docker compose up -d` and `dotrun`
- Visit http://127.0.0.1:8030/security/notices.json and see that structure of `related_notices` in the payload is unchanged when compared to main (this is purely a performance fix so the json structure should not change at all)

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
