### PR TITLE
ci: prepend `FLASK` to sentry keys to prevent instantiating raven

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.flask-base @ git+https://github.com/canonical/canonicalwebteam.flask-base@add-compression-override-option
+canonicalwebteam.flask-base==3.1.1
 setuptools<81
 alchemy-mock==0.4.3
 apispec==4.7.1


### PR DESCRIPTION
## Done

- Prepend `FLASK_` to Sentry keys in konf files
- We are using the new Sentry DSN, this way Sentry does not instantiate the decommissioned Sentry with Raven, previously throwing error

## QA

- Check out the branch locally
- Run `docker compose up -d` and `dotrun`


## Issue / Card

Fixes [WD-37938](https://warthogs.atlassian.net/browse/WD-37938)

## Screenshots

[if relevant, include a screenshot]


[WD-37938]: https://warthogs.atlassian.net/browse/WD-37938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ