### PR TITLE
build: pin flask version for pack-rock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+flask==2.3.3
 canonicalwebteam.flask-base @ git+https://github.com/canonical/canonicalwebteam.flask-base@add-compression-override-option
 setuptools<81
 alchemy-mock==0.4.3


### PR DESCRIPTION
## Done

- Pin Flask version in `requirements.txt` for `pack-rock` action to pass
- Note: it is expected for `publish-image` to fail as there are missing permissions to publish the image from PR. This workflow would usually only run on pushes to main.

## QA

- See that `pack-rock` action passes in the CI actions below


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
