### PR TITLE
ci: grant packages:write to publish-image job

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -58,6 +58,9 @@ jobs:
   publish-image:
     runs-on: ubuntu-latest
     needs: pack-rock
+    permissions:
+      contents: read
+      packages: write
     outputs:
       image_url: ${{ steps.set_image_url.outputs.image_url }}
     steps:


### PR DESCRIPTION
## Done

- Grant permissions to publish-image job
- Fixes [this failing error](https://github.com/canonical/ubuntu-com-security-api/actions/runs/30433794327/job/90517938499)
- Similar to permissions on c.com [example](https://github.com/canonical/canonical.com/blob/main/.github/workflows/deploy.yaml#L104)


## QA
- See that `publish-image` action passes

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
