### PR TITLE
build: Revert flask pinned version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-flask==2.3.3
 canonicalwebteam.flask-base @ git+https://github.com/canonical/canonicalwebteam.flask-base@add-compression-override-option
 setuptools<81
 alchemy-mock==0.4.3


### PR DESCRIPTION
## Done

- Revert changes in https://github.com/canonical/ubuntu-com-security-api/pull/286
- It fixes the pack rock action, but was causing API issues on querying and updating
- Reverting for now as the API lives on ps5 and will not need the pack-rock fix

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Run through the following [QA steps](https://canonical-web-and-design.github
.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been reso
lved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
