### PR TITLE
Increase Gunicorn workers from 3 to 5

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -20,4 +20,4 @@ if [ -z "${GUNICORN_TIMEOUT}" ]; then
 else
     WORKER_TIMEOUT="${GUNICORN_TIMEOUT}"
 fi
-talisker.gunicorn webapp.app:app --bind $1 --workers 3 --name talisker-$(hostname) ${DEBUG_ARGS} --timeout $WORKER_TIMEOUT
+talisker.gunicorn webapp.app:app --bind $1 --workers 5 --name talisker-$(hostname) ${DEBUG_ARGS} --timeout $WORKER_TIMEOUT


### PR DESCRIPTION
## Done

- Increase Gunicorn workers from 3 to 5 to stop pods getting blocked by heavy workloads

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Run through the following [QA steps](https://canonical-web-and-design.github
.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been reso
lved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
