### PR TITLE
Increase GUNICORN worker timeout from 30 to 60 seconds

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -16,7 +16,7 @@ FLASK_APP=webapp.app flask db upgrade
 # Start server
 # ===
 if [ -z "${GUNICORN_TIMEOUT}" ]; then
-    WORKER_TIMEOUT="30"
+    WORKER_TIMEOUT="60"
 else
     WORKER_TIMEOUT="${GUNICORN_TIMEOUT}"
 fi


### PR DESCRIPTION
## Done

- Increase GUNICORN worker timeout from 30 to 60 seconds

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Run through the following [QA steps](https://canonical-web-and-design.github
.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been reso
lved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
