### PR TITLE
Load only the packages a bulk upsert actually references

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -326,9 +326,20 @@ def bulk_upsert_cve(*args, **kwargs):
             413,
         )
 
+    # Load only the packages this batch references: the full table is ~1.5MB
+    # of rows fetched for nothing but membership tests. New packages created
+    # below are still added to this dict and reused across the batch.
+    wanted_packages = {
+        package_data["name"]
+        for data in cves_data
+        for package_data in data.get("packages", [])
+    }
     packages = {}
-    for package in Package.query.all():
-        packages[package.name] = package
+    if wanted_packages:
+        for package in Package.query.filter(
+            Package.name.in_(wanted_packages)
+        ):
+            packages[package.name] = package
 
     for data in cves_data:
         update_cve = False


### PR DESCRIPTION
## Done

- `bulk_upsert_cve` now loads only the packages the submitted batch references, instead of the full package table (~1.5MB of rows fetched purely for membership tests, which alone tripped the read `statement_timeout` and 503ed single-CVE updates)
- New packages created mid-batch are still added to the dict and reused across the batch, exactly as before

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- `PUT /security/updates/cves.json` with a payload containing existing and new packages: 200, statuses identical to before
- `TEST_DATABASE_URL=<url> SECRET_KEY=x python3 -m unittest discover tests`

## Issue / Card

Part of the `/security/cves.json` outage remediation (PR 6 of 6). Independent — can merge in any order.

## Screenshots

Not relevant (API-only change).
